### PR TITLE
packaging-nix: fix broken `git+file:.` input

### DIFF
--- a/packaging/nix/README.md
+++ b/packaging/nix/README.md
@@ -283,7 +283,7 @@ Here is a more complete `flake.nix` containing `devShells` available to
         jq
         bat
       ];
-    }
+    };
   };
 }
 ```

--- a/packaging/nix/flake.lock
+++ b/packaging/nix/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680527215,
+        "narHash": "sha256-X62JISWeukC20t30XQbd9q0lf891zim7KqB3aRd0ieA=",
+        "owner": "VILLASframework",
+        "repo": "common",
+        "rev": "d0b6edfe2a93297e0caf218738495686497a3dd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "VILLASframework",
+        "repo": "common",
+        "type": "github"
+      }
+    },
     "lib60870": {
       "flake": false,
       "locked": {
@@ -36,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683023950,
-        "narHash": "sha256-wG7aeu8o+tbf8VaQMDZYQ3kG3nYjklyKjUENVWPrcYY=",
+        "lastModified": 1685031212,
+        "narHash": "sha256-lYRWOQG/YKNEeY0LPPKl6KphN+iEUWAhlXTx3oJgECA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "826418fc35e4cd6e85a88edd389cb249a7aa9671",
+        "rev": "bfa58af4da4ca3cf3f98092b1425cbb25ff7e341",
         "type": "github"
       },
       "original": {
@@ -51,25 +67,10 @@
     },
     "root": {
       "inputs": {
+        "common": "common",
         "lib60870": "lib60870",
         "libiec61850": "libiec61850",
-        "nixpkgs": "nixpkgs",
-        "src": "src"
-      }
-    },
-    "src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1683025627,
-        "narHash": "sha256-22uKohl9nRAkhPgnOjnXzqOR1FWMpcDNSSNbkUHud5Y=",
-        "submodules": true,
-        "type": "git",
-        "url": "file:."
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "file:."
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/packaging/nix/flake.nix
+++ b/packaging/nix/flake.nix
@@ -4,8 +4,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
 
-    src = {
-      url = "git+file:.?submodules=1";
+    common = {
+      url = "github:VILLASframework/common?submodules=1";
       flake = false;
     };
 
@@ -43,7 +43,8 @@
         default = villas;
 
         villas-minimal = pkgs.callPackage ./villas.nix {
-          inherit (inputs) src;
+          src = ../..;
+          common = inputs.common;
         };
 
         villas = villas-minimal.override {

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -1,6 +1,7 @@
 {
   # build dependencies
   cmake,
+  common,
   lib,
   makeWrapper,
   pkg-config,
@@ -61,6 +62,9 @@ stdenv.mkDerivation {
     # 'array-bounds' and 'stringop-overflow' for villas-relay
     "-DCMAKE_CXX_FLAGS_RELEASE=-Wno-error"
   ];
+  preConfigure = ''
+    rm -d common && ln -sf ${common} common
+  '';
   postInstall = ''
     wrapProgram $out/bin/villas \
       --set PATH ${lib.makeBinPath [(placeholder "out") gnugrep]}


### PR DESCRIPTION
The `src` input was working locally due to a bug in the `nix` flake evaluation. The input itself was malformed and not reproducable.