### PR TITLE
tools/villas: improve script behaviour for `-h` or `--help`

### DIFF
--- a/tools/villas
+++ b/tools/villas
@@ -22,8 +22,8 @@ SUBTOOL=$1
 ARGS=${@:2}
 
 # Check if tool is available
-if ! echo ${SUBTOOLS} | grep -w -q ${SUBTOOL}; then
-	echo "Usage: villas [TOOL]"
+if ! echo ${SUBTOOLS} | grep -wqFe "${SUBTOOL}"; then
+	echo "Usage: villas [-h | --help | TOOL]"
 	echo "  TOOL     is one of ${SUBTOOLS}"
 	echo
 	echo "For detailed documentation, please see: 'villas node'"
@@ -32,7 +32,8 @@ if ! echo ${SUBTOOLS} | grep -w -q ${SUBTOOL}; then
 
 	# Show VILLASnode copyright and contact info
 	villas-node -h | tail -n3
-	exit 1
+	echo "-h" "--help" | grep -wqFe "${SUBTOOL}"
+	exit $?
 fi
 
 exec villas-${SUBTOOL} ${ARGS}


### PR DESCRIPTION
- Quote `${SUBTOOL}` in case it is set but empty
- Add `-e` flag to `grep` so `villas --help` does not show `grep --help`
- Add `-F` flag to `grep` so `villas "[ "` does not show a regexp error
- Don't exit with error when `-h` or `--help` was specified
- Add `-h` and `--help` to `Usage` in the help message.