### PR TITLE
packaging-nix: Add `direnv` support and improve packaging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if direnv_version "2.30.0" \
+&& has nix \
+&& nix show-config experimental-features 2>/dev/null | grep -wqF flakes
+then
+    watch_file ./packaging/nix/*.nix
+    use flake ./packaging/nix
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .cproject
 .settings/
 .vscode/
+.direnv/
 
 *.egg-info/
 

--- a/packaging/nix/flake.nix
+++ b/packaging/nix/flake.nix
@@ -37,8 +37,9 @@
     );
   in {
     formatter = forSupportedSystems (system: legacyPackages.${system}.alejandra);
-    packages = forSupportedSystems (system:
-      let pkgs = legacyPackages.${system};
+    packages = forSupportedSystems (
+      system: let
+        pkgs = legacyPackages.${system};
       in rec {
         default = villas;
 
@@ -62,22 +63,36 @@
         };
       }
     );
-    devShells = forSupportedSystems (system:
-      let pkgs = legacyPackages.${system};
+    devShells = forSupportedSystems (
+      system: let
+        pkgs = legacyPackages.${system};
+        shellHook = ''
+          [ -z "$PS1" ] || exec $SHELL
+        '';
       in rec {
         default = full;
 
         minimal = pkgs.mkShell {
+          inherit shellHook;
           name = "minimal";
-          shellHook = "exec $SHELL";
-          inputsFrom = [ pkgs.villas-minimal ];
+          inputsFrom = [pkgs.villas-minimal];
         };
 
         full = pkgs.mkShell {
+          inherit shellHook;
           name = "full";
-          shellHook = "exec $SHELL";
-          inputsFrom = [ pkgs.villas ];
+          inputsFrom = [pkgs.villas];
         };
+      }
+    );
+    checks = forSupportedSystems (
+      system: let
+        pkgs = legacyPackages.${system};
+      in {
+        fmt = pkgs.runCommand "check-fmt" {} ''
+          cd ${self}
+          ${pkgs.alejandra}/bin/alejandra --check . 2> $out
+        '';
       }
     );
   };

--- a/packaging/nix/lib60870.nix
+++ b/packaging/nix/lib60870.nix
@@ -2,7 +2,7 @@
   cmake,
   lib,
   stdenv,
-  src
+  src,
 }:
 stdenv.mkDerivation {
   pname = "lib60870";

--- a/packaging/nix/libiec61850.nix
+++ b/packaging/nix/libiec61850.nix
@@ -2,7 +2,7 @@
   cmake,
   lib,
   stdenv,
-  src
+  src,
 }:
 stdenv.mkDerivation {
   pname = "libiec61850";

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -26,6 +26,7 @@
   withNodeSocket ? withAllNodes,
   # dependencies
   comedilib,
+  coreutils,
   curl,
   czmq,
   gnugrep,
@@ -48,7 +49,7 @@
   protobufc,
   rdkafka,
   rdma-core,
-  spdlog
+  spdlog,
 }:
 stdenv.mkDerivation {
   pname = "villas";
@@ -67,36 +68,36 @@ stdenv.mkDerivation {
   '';
   postInstall = ''
     wrapProgram $out/bin/villas \
-      --set PATH ${lib.makeBinPath [(placeholder "out") gnugrep]}
+      --set PATH ${lib.makeBinPath [(placeholder "out") gnugrep coreutils]}
   '';
   nativeBuildInputs = [
     cmake
     makeWrapper
     pkg-config
   ];
-  buildInputs = [
-    jansson
-    libwebsockets
-    libuuid
-    openssl
-    curl
-    spdlog
-  ]
-    ++ lib.optionals withConfig         [libconfig]
-    ++ lib.optionals withProtobuf       [protobuf protobufc]
-    ++ lib.optionals withNodeComedi     [comedilib]
-    ++ lib.optionals withNodeZeromq     [czmq libsodium]
-    ++ lib.optionals withNodeIec60870   [lib60870]
-    ++ lib.optionals withNodeIec61850   [libiec61850]
-    ++ lib.optionals withNodeSocket     [libnl]
-    ++ lib.optionals withNodeRtp        [libre]
-    ++ lib.optionals withNodeUldaq      [libuldaq]
-    ++ lib.optionals withNodeTemper     [libusb]
-    ++ lib.optionals withNodeMqtt       [mosquitto]
-    ++ lib.optionals withNodeNanomsg    [nanomsg]
-    ++ lib.optionals withNodeKafka      [rdkafka]
-    ++ lib.optionals withNodeInfiniband [rdma-core]
-    ;
+  buildInputs =
+    [
+      jansson
+      libwebsockets
+      libuuid
+      openssl
+      curl
+      spdlog
+    ]
+    ++ lib.optionals withConfig [libconfig]
+    ++ lib.optionals withProtobuf [protobuf protobufc]
+    ++ lib.optionals withNodeComedi [comedilib]
+    ++ lib.optionals withNodeZeromq [czmq libsodium]
+    ++ lib.optionals withNodeIec60870 [lib60870]
+    ++ lib.optionals withNodeIec61850 [libiec61850]
+    ++ lib.optionals withNodeSocket [libnl]
+    ++ lib.optionals withNodeRtp [libre]
+    ++ lib.optionals withNodeUldaq [libuldaq]
+    ++ lib.optionals withNodeTemper [libusb]
+    ++ lib.optionals withNodeMqtt [mosquitto]
+    ++ lib.optionals withNodeNanomsg [nanomsg]
+    ++ lib.optionals withNodeKafka [rdkafka]
+    ++ lib.optionals withNodeInfiniband [rdma-core];
   meta = with lib; {
     description = "a tool connecting real-time power grid simulation equipment";
     homepage = "https://villas.fein-aachen.org/";


### PR DESCRIPTION
- Improve the `shellHook` of the `devShells`.
- Format all Nix code using `alejandra`.
- Add [`direnv`](https://direnv.net/) support using the Nix packaging.