### PR TITLE
packaging-nix: use the 22.11 release of nixpkgs

### DIFF
--- a/packaging/nix/flake.lock
+++ b/packaging/nix/flake.lock
@@ -89,15 +89,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686671746,
-        "narHash": "sha256-cPVdpUv+PzLuF6EFWPwtkT42Y6lomSA3npmW+Yzx878=",
+        "lastModified": 1686656800,
+        "narHash": "sha256-duScdQZNeZcde0JwmQ9W4XfqlO/Z24MDhlTq2MokuSM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4ab538636f64f624c49cef4393d1a0d4ebf12a66",
+        "rev": "2b273c2351fe1ab490158cf8acc8aafad02592ce",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/packaging/nix/flake.nix
+++ b/packaging/nix/flake.nix
@@ -2,7 +2,7 @@
   description = "a tool for connecting real-time power grid simulation equipment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
 
     common = {
       url = "github:VILLASframework/common";

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -7,19 +7,19 @@
   withAllHooks ? false,
   withAllNodes ? false,
   withExtraConfig ? withAllExtras,
-  withExtraGraphviz ? false, # unknown type boolean in villas-graph
+  withExtraGraphviz ? withAllExtras,
   withFormatProtobuf ? withAllFormats,
-  withHookLua ? false, # deprecated functions
-  withNodeAmqp ? false, # deprecated functions
+  withHookLua ? withAllHooks,
+  withNodeAmqp ? withAllNodes,
   withNodeComedi ? withAllNodes,
-  withNodeFpga ? false, # spdlog formatting error
+  withNodeFpga ? false, # submodule commit has warnings and master broke the interface
   withNodeIec60870 ? withAllNodes,
   withNodeIec61850 ? withAllNodes,
   withNodeInfiniband ? withAllNodes,
   withNodeKafka ? withAllNodes,
   withNodeMqtt ? withAllNodes,
   withNodeNanomsg ? withAllNodes,
-  withNodeRedis ? false, # spdlog formatting error
+  withNodeRedis ? withAllNodes,
   withNodeRtp ? withAllNodes,
   withNodeSocket ? withAllNodes,
   withNodeTemper ? withAllNodes,
@@ -73,7 +73,6 @@ stdenv.mkDerivation {
     [
       "-DDOWNLOAD_GO=OFF"
       "-DCMAKE_BUILD_TYPE=Release"
-      "-DCMAKE_CXX_FLAGS_RELEASE=-Wno-error=maybe-uninitialized"
     ]
     ++ lib.optionals withFormatProtobuf ["-DCMAKE_FIND_ROOT_PATH=${protobufcBuildBuild}/bin"];
   preConfigure = ''


### PR DESCRIPTION
We don't wan't to use unstable or 23.05 to circumvent deprecation warnings and spdlog/fmt related regressions.
More node types can now be compiled into villas-full.

The FPGA node type is still disabled due to compiler warnings in the submodules current commit.