### PR TITLE
fix villas tools installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,8 @@ endif()
 if(WITH_GRAPHVIZ)
     add_executable(villas-graph villas-graph.cpp)
     target_link_libraries(villas-graph PUBLIC villas)
+
+    list(APPEND SRCS villas-graph)
 endif()
 
 if(WITH_WEB)
@@ -64,8 +66,8 @@ endif()
 if(LIBZMQ_FOUND)
     add_executable(villas-zmq-keygen villas-zmq-keygen.cpp)
     target_link_libraries(villas-zmq-keygen PUBLIC villas-common PkgConfig::LIBZMQ)
-    
-    list(APPEND SRC villas-zmq-keygen)
+
+    list(APPEND SRCS villas-zmq-keygen)
 endif()
 
 if(WITH_HOOKS)

--- a/tools/villas
+++ b/tools/villas
@@ -13,7 +13,7 @@
 ###################################################################################
 
 # Get a list of all available tools
-SUBTOOLS="node compare pipe hook conf2json convert graph relay signal test-config test-rtt zmq-keygen"
+SUBTOOLS="api node compare pipe hook conf2json convert graph relay signal test-config test-rtt zmq-keygen"
 
 # First argument to wrapper is the tool which should be started
 SUBTOOL=$1


### PR DESCRIPTION
Currently `villas-graph` and `villas-zmq-keygen` aren't being installed and `villas-api` is not accessible as a subcommand of the `villas` script.