### PR TITLE
packaging-nix: improvements

### DIFF
--- a/lib/nodes/iec60870.cpp
+++ b/lib/nodes/iec60870.cpp
@@ -203,7 +203,7 @@ std::optional<ASDUData::Sample> ASDUData::checkASDU(CS101_ASDU const &asdu) cons
 			}
 
 			default:
-				assert(!"unreachable");
+				throw RuntimeError { "unsupported asdu type" };
 		}
 
 		std::optional<CP56Time2a> time_cp56;
@@ -761,7 +761,7 @@ int SlaveNode::parse(json_t *json, const uuid_t sn_uuid)
 						break;
 
 					default:
-						assert(!"unreachable");
+						throw RuntimeError { "unsupported signal type" };
 				}
 			} else
 				initial_value.f = 0.0;

--- a/packaging/nix/lib60870.nix
+++ b/packaging/nix/lib60870.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation {
   pname = "lib60870";
   version = "villas";
   src = src;
+  separateDebugInfo = true;
   nativeBuildInputs = [cmake];
   preConfigure = "cd lib60870-C";
   meta = with lib; {

--- a/packaging/nix/libdatachannel.nix
+++ b/packaging/nix/libdatachannel.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation {
   pname = "libdatachannel";
   version = "villas";
   src = src;
+  separateDebugInfo = true;
   nativeBuildInputs = [cmake pkg-config];
   buildInputs = [libnice libpcap openssl];
   cmakeFlags = [

--- a/packaging/nix/libiec61850.nix
+++ b/packaging/nix/libiec61850.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation {
   pname = "libiec61850";
   version = "villas";
   src = src;
+  separateDebugInfo = true;
   nativeBuildInputs = [cmake];
   meta = with lib; {
     description = "open-source library for the IEC 61850 protocols";

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -33,6 +33,7 @@
   coreutils,
   fpga,
   graphviz,
+  jq,
   lib,
   makeWrapper,
   pkg-config,
@@ -70,7 +71,11 @@
 stdenv.mkDerivation {
   inherit src version;
   pname = "villas";
-  cmakeFlags = []
+  outputs = ["out" "dev"];
+  cmakeFlags =
+    [
+      "-DDOWNLOAD_GO=OFF"
+    ]
     ++ lib.optionals (!withGpl) ["-DWITHOUT_GPL=ON"]
     ++ lib.optionals withFormatProtobuf ["-DCMAKE_FIND_ROOT_PATH=${protobufcBuildBuild}/bin"];
   postPatch = ''
@@ -85,6 +90,8 @@ stdenv.mkDerivation {
   postInstall = ''
     wrapProgram $out/bin/villas \
       --set PATH ${lib.makeBinPath [(placeholder "out") gnugrep coreutils]}
+    wrapProgram $out/bin/villas-api \
+      --set PATH ${lib.makeBinPath [coreutils curl jq]}
   '';
   nativeBuildInputs = [
     cmake

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation {
   inherit src version;
   pname = "villas";
   outputs = ["out" "dev"];
+  separateDebugInfo = true;
   cmakeFlags = []
     ++ lib.optionals (!withGpl) ["-DWITHOUT_GPL=ON"]
     ++ lib.optionals withFormatProtobuf ["-DCMAKE_FIND_ROOT_PATH=${protobufcBuildBuild}/bin"];

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -72,10 +72,7 @@ stdenv.mkDerivation {
   inherit src version;
   pname = "villas";
   outputs = ["out" "dev"];
-  cmakeFlags =
-    [
-      "-DDOWNLOAD_GO=OFF"
-    ]
+  cmakeFlags = []
     ++ lib.optionals (!withGpl) ["-DWITHOUT_GPL=ON"]
     ++ lib.optionals withFormatProtobuf ["-DCMAKE_FIND_ROOT_PATH=${protobufcBuildBuild}/bin"];
   postPatch = ''

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -2,6 +2,7 @@
   # general configuration
   src,
   version,
+  withGpl ? true,
   withAllExtras ? false,
   withAllFormats ? false,
   withAllHooks ? false,
@@ -69,12 +70,12 @@
 stdenv.mkDerivation {
   inherit src version;
   pname = "villas";
-  cmakeFlags =
-    [
-      "-DDOWNLOAD_GO=OFF"
-      "-DCMAKE_BUILD_TYPE=Release"
-    ]
+  cmakeFlags = []
+    ++ lib.optionals (!withGpl) ["-DWITHOUT_GPL=ON"]
     ++ lib.optionals withFormatProtobuf ["-DCMAKE_FIND_ROOT_PATH=${protobufcBuildBuild}/bin"];
+  postPatch = ''
+    patchShebangs --host ./tools
+  '';
   preConfigure = ''
     rm -df common
     rm -df fpga
@@ -82,7 +83,6 @@ stdenv.mkDerivation {
     ${lib.optionalString withNodeFpga "ln -s ${fpga} fpga"}
   '';
   postInstall = ''
-    patchShebangs --build $out/bin/villas
     wrapProgram $out/bin/villas \
       --set PATH ${lib.makeBinPath [(placeholder "out") gnugrep coreutils]}
   '';


### PR DESCRIPTION
- Add separate debug info to all packages to allow for easier debugging of release binaries.
- Add wrapper for `villas-api` with all required tools
- Fix some release compile errors
- Remove obsolete `DOWNLOAD_GO=OFF` cmake option