### PR TITLE
Remove usage of std::filesystem

### DIFF
--- a/include/villas/config_class.hpp
+++ b/include/villas/config_class.hpp
@@ -33,7 +33,7 @@ protected:
   Logger logger;
 
   std::list<std::string> includeDirectories;
-  std::filesystem::path configPath;
+  std::string configPath;
 
   // Check if file exists on local system.
   static bool isLocalFile(const std::string &uri) {
@@ -90,7 +90,7 @@ public:
   json_t *load(const std::string &u, bool resolveIncludes = true,
                bool resolveEnvVars = true);
 
-  std::filesystem::path &getConfigPath() { return configPath; }
+  std::string &getConfigPath() { return configPath; }
 };
 
 } // namespace node

--- a/include/villas/super_node.hpp
+++ b/include/villas/super_node.hpp
@@ -143,7 +143,7 @@ public:
 
   json_t *getConfig() { return config.root; }
 
-  std::filesystem::path &getConfigPath() { return config.getConfigPath(); }
+  std::string &getConfigPath() { return config.getConfigPath(); }
 
   std::string getConfigUri() const { return uri; }
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -72,7 +72,13 @@ json_t *Config::load(const std::string &u, bool resolveInc,
 
 FILE *Config::loadFromStdio() {
   logger->info("Reading configuration from standard input");
-  configPath = std::filesystem::current_path();
+
+  auto *cwd = new char[PATH_MAX];
+
+  configPath = getcwd(cwd, PATH_MAX);
+
+  delete[] cwd;
+
   return stdin;
 }
 

--- a/lib/nodes/fpga.cpp
+++ b/lib/nodes/fpga.cpp
@@ -203,7 +203,7 @@ int FpgaNodeFactory::start(SuperNode *sn) {
   vfioContainer = std::make_shared<kernel::vfio::Container>();
 
   if (cards.empty()) {
-    std::filesystem::path searchPath = sn->getConfigPath().parent_path();
+    std::string searchPath = sn->getConfigPath() + "/..";
     createCards(sn->getConfig(), cards, searchPath);
   }
 


### PR DESCRIPTION
This PR removes any usage of `std::filesystem` in VILLASnode. This is required as OPAL-RTLinux systems currently ship with GCC 8.3.0 which comes without support for `libstdc++-fs`.

I plan to re-introduce these changes once OPAL-RTLinux updates its compiler.