### PR TITLE
file: Make directories listable when created

### DIFF
--- a/lib/nodes/file.cpp
+++ b/lib/nodes/file.cpp
@@ -230,7 +230,7 @@ int villas::node::file_start(NodeCompat *n) {
   ret = stat(dir, &sb);
   if (ret) {
     if (errno == ENOENT || errno == ENOTDIR) {
-      ret = mkdir(dir, 0644);
+      ret = mkdir(dir, 0755);
       if (ret)
         throw SystemError("Failed to create directory");
     } else if (errno != EISDIR)


### PR DESCRIPTION
Fixes #728 

We used the wrong mode (0644) when creating non-existing directories in the `uri` path.
As a result the newly-created directories where missing the executable bit which in turn resulted in an `E_ACCESS` error and the subsequent failure to start the file node.

@al3xa23 