### PR TITLE
node: Fix null-pointer dereference for internal loopback nodes

### DIFF
--- a/lib/node.cpp
+++ b/lib/node.cpp
@@ -74,7 +74,10 @@ Node::~Node() {
   rtnl_cls_put(tc_classifier);
 #endif // WITH_NETEM
 
-  factory->instances.remove(this);
+  // Internal loopback nodes have no factory
+  // Only attempt removal for factories of other node-types.
+  if (factory != nullptr)
+    factory->instances.remove(this);
 }
 
 int Node::prepare() {


### PR DESCRIPTION
This is another approach at fixing the segmentation fault involving internal loopback nodes.

@pipeacosta This solves the underlying problem (null pointer dereference) rather than avoid calling the `villas::node::~Node()` like you did in #724.

I think this is a cleaner approach as we still call the `villas::node::Node` constructor from the `villas::node::InternalLoopbackNode` constructor.

Closes #724 