### PR TITLE
cmake: fix common not being installed

### DIFF
--- a/common/lib/CMakeLists.txt
+++ b/common/lib/CMakeLists.txt
@@ -87,7 +87,7 @@ install(
 )
 
 install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/common/include/villas/
+    DIRECTORY ${CMAKE_SOURCE_DIR}/common/include/villas/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/villas
     COMPONENT devel
     FILES_MATCHING
@@ -96,7 +96,7 @@ install(
 )
 
 install(
-    DIRECTORY ${PROJECT_BINARY_DIR}/include/villas/
+    DIRECTORY ${PROJECT_BINARY_DIR}/common/include/villas/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/villas
     COMPONENT devel
     FILES_MATCHING


### PR DESCRIPTION
The DPsim container is broken because of this mistake. I know there are many ways to fix this, so feel free to chose another one :)

sorry for these small PRs.