### PR TITLE
Refactor: Split core make into multiple functions

### DIFF
--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -209,6 +209,9 @@ public:
 
   static std::list<IpIdentifier> parseVLNV(json_t *json_ips);
   static std::list<IpIdentifier> reorderIps(std::list<IpIdentifier> allIps);
+  static std::list<std::shared_ptr<Core>>
+  configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
+               Card *card);
 
   // Returns a running and checked FPGA IP
   static std::list<std::shared_ptr<Core>> make(Card *card, json_t *json_ips);

--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -207,6 +207,8 @@ class CoreFactory : public plugin::Plugin {
 public:
   using plugin::Plugin::Plugin;
 
+  static std::list<IpIdentifier> parseVLNV(json_t *json_ips);
+
   // Returns a running and checked FPGA IP
   static std::list<std::shared_ptr<Core>> make(Card *card, json_t *json_ips);
 

--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -208,6 +208,7 @@ public:
   using plugin::Plugin::Plugin;
 
   static std::list<IpIdentifier> parseVLNV(json_t *json_ips);
+  static std::list<IpIdentifier> reorderIps(std::list<IpIdentifier> allIps);
 
   // Returns a running and checked FPGA IP
   static std::list<std::shared_ptr<Core>> make(Card *card, json_t *json_ips);

--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -212,6 +212,7 @@ public:
   static std::list<std::shared_ptr<Core>>
   configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
                Card *card);
+  static void initIps(std::list<std::shared_ptr<Core>> orderedIps, Card *card);
 
   // Returns a running and checked FPGA IP
   static std::list<std::shared_ptr<Core>> make(Card *card, json_t *json_ips);

--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -207,7 +207,7 @@ class CoreFactory : public plugin::Plugin {
 public:
   using plugin::Plugin::Plugin;
 
-  static std::list<IpIdentifier> parseVLNV(json_t *json_ips);
+  static std::list<IpIdentifier> parseIpIdentifier(json_t *json_ips);
   static std::list<IpIdentifier> reorderIps(std::list<IpIdentifier> allIps);
   static std::list<std::shared_ptr<Core>>
   configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -37,7 +37,7 @@ static std::list<Vlnv> vlnvInitializationOrder = {
     Vlnv("xilinx.com:ip:axi_iic:"),
 };
 
-std::list<IpIdentifier> CoreFactory::parseVLNV(json_t *json_ips) {
+std::list<IpIdentifier> CoreFactory::parseIpIdentifier(json_t *json_ips) {
   // Parse all IP instance names and their VLNV into list `allIps`
   std::list<IpIdentifier> allIps;
 
@@ -302,7 +302,7 @@ std::list<std::shared_ptr<Core>> CoreFactory::make(Card *card,
   }
 
   std::list<IpIdentifier> allIps =
-      parseVLNV(json_ips); // All IPs available in config
+      parseIpIdentifier(json_ips); // All IPs available in config
 
   std::list<IpIdentifier> orderedIps =
       reorderIps(allIps); // IPs ordered in initialization order

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -54,7 +54,7 @@ std::list<IpIdentifier> CoreFactory::parseVLNV(json_t *json_ips) {
     allIps.push_back({vlnv, ipName});
   }
   return allIps;
-  }
+}
 
 std::list<IpIdentifier>
 CoreFactory::reorderIps(std::list<IpIdentifier> allIps) {
@@ -86,6 +86,7 @@ CoreFactory::reorderIps(std::list<IpIdentifier> allIps) {
 
   return orderedIps;
 }
+
 std::list<std::shared_ptr<Core>>
 CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
                           Card *card) {
@@ -241,6 +242,7 @@ CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
 
   return configuredIps;
 }
+
 void CoreFactory::initIps(std::list<std::shared_ptr<Core>> configuredIps,
                           Card *card) {
   auto loggerStatic = CoreFactory::getStaticLogger();

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -310,7 +310,7 @@ std::list<std::shared_ptr<Core>> CoreFactory::make(Card *card,
   std::list<std::shared_ptr<Core>> configuredIps =
       configureIps(orderedIps, json_ips, card); // Successfully configured IPs
 
-  (void) initIps(configuredIps, card);
+  initIps(configuredIps, card);
 
   return card->ips;
 }

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -241,6 +241,9 @@ CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
 
   return configuredIps;
 }
+void CoreFactory::initIps(std::list<std::shared_ptr<Core>> configuredIps,
+                          Card *card) {
+  auto loggerStatic = CoreFactory::getStaticLogger();
   // Start and check IPs now
   for (auto &ip : configuredIps) {
     loggerStatic->info("Initializing {}", *ip);
@@ -284,6 +287,7 @@ CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
   for (auto &ip : card->ips) {
     loggerStatic->debug("  {}", *ip);
   }
+}
 
   return card->ips;
 }

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -289,6 +289,27 @@ void CoreFactory::initIps(std::list<std::shared_ptr<Core>> configuredIps,
   }
 }
 
+std::list<std::shared_ptr<Core>> CoreFactory::make(Card *card,
+                                                   json_t *json_ips) {
+  // We only have this logger until we know the factory to build an IP with
+  auto loggerStatic = getStaticLogger();
+
+  if (!card->ips.empty()) {
+    loggerStatic->error("IP list of card {} already contains IPs.", card->name);
+    throw RuntimeError("IP list of card {} already contains IPs.", card->name);
+  }
+
+  std::list<IpIdentifier> allIps =
+      parseVLNV(json_ips); // All IPs available in config
+
+  std::list<IpIdentifier> orderedIps =
+      reorderIps(allIps); // IPs ordered in initialization order
+
+  std::list<std::shared_ptr<Core>> configuredIps =
+      configureIps(orderedIps, json_ips, card); // Successfully configured IPs
+
+  (void) initIps(configuredIps, card);
+
   return card->ips;
 }
 

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -86,6 +86,11 @@ CoreFactory::reorderIps(std::list<IpIdentifier> allIps) {
 
   return orderedIps;
 }
+std::list<std::shared_ptr<Core>>
+CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
+                          Card *card) {
+  std::list<std::shared_ptr<Core>> configuredIps;
+  auto loggerStatic = CoreFactory::getStaticLogger();
   // Configure all IPs
   for (auto &id : orderedIps) {
     loggerStatic->info("Configuring {}", id);
@@ -234,6 +239,8 @@ CoreFactory::reorderIps(std::list<IpIdentifier> allIps) {
     configuredIps.push_back(std::move(ip));
   }
 
+  return configuredIps;
+}
   // Start and check IPs now
   for (auto &ip : configuredIps) {
     loggerStatic->info("Initializing {}", *ip);

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -37,21 +37,10 @@ static std::list<Vlnv> vlnvInitializationOrder = {
     Vlnv("xilinx.com:ip:axi_iic:"),
 };
 
-std::list<std::shared_ptr<Core>> CoreFactory::make(Card *card,
-                                                   json_t *json_ips) {
-  // We only have this logger until we know the factory to build an IP with
-  auto loggerStatic = getStaticLogger();
-
-  std::list<IpIdentifier> allIps;     // All IPs available in config
-  std::list<IpIdentifier> orderedIps; // IPs ordered in initialization order
-
-  std::list<std::shared_ptr<Core>> configuredIps; // Successfully configured IPs
-
-  if (!card->ips.empty()) {
-    loggerStatic->error("IP list of card {} already contains IPs.", card->name);
-    throw RuntimeError("IP list of card {} already contains IPs.", card->name);
-  }
+std::list<IpIdentifier> CoreFactory::parseVLNV(json_t *json_ips) {
   // Parse all IP instance names and their VLNV into list `allIps`
+  std::list<IpIdentifier> allIps;
+
   const char *ipName;
   json_t *json_ip;
   json_object_foreach(json_ips, ipName, json_ip) {
@@ -63,6 +52,8 @@ std::list<std::shared_ptr<Core>> CoreFactory::make(Card *card,
       throw ConfigError(json_ip, err, "", "IP {} has no VLNV", ipName);
 
     allIps.push_back({vlnv, ipName});
+  }
+  return allIps;
   }
 
   // Pick out IPs to be initialized first.

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -56,8 +56,11 @@ std::list<IpIdentifier> CoreFactory::parseVLNV(json_t *json_ips) {
   return allIps;
   }
 
+std::list<IpIdentifier>
+CoreFactory::reorderIps(std::list<IpIdentifier> allIps) {
   // Pick out IPs to be initialized first.
-  //
+  std::list<IpIdentifier> orderedIps;
+
   // Reverse walktrough, because we push to the
   // front of the output list, so that the first element will also be the
   // first to be initialized.
@@ -75,11 +78,14 @@ std::list<IpIdentifier> CoreFactory::parseVLNV(json_t *json_ips) {
   // Insert all other IPs at the end
   orderedIps.splice(orderedIps.end(), allIps);
 
+  auto loggerStatic = CoreFactory::getStaticLogger();
   loggerStatic->debug("IP initialization order:");
   for (auto &id : orderedIps) {
     loggerStatic->debug("  " CLR_BLD("{}"), id.getName());
   }
 
+  return orderedIps;
+}
   // Configure all IPs
   for (auto &id : orderedIps) {
     loggerStatic->info("Configuring {}", id);


### PR DESCRIPTION
Seperate the core factory make method into multiple parts to improve readability, reusability and mainainability.
Verified to work as expected on miob hardware.
In addition, #783 will implement features which require the seperation of parsing and initialization.