### PR TITLE
VfioContainer: Make "getOrAttachGroup" method public

### DIFF
--- a/common/include/villas/kernel/vfio_container.hpp
+++ b/common/include/villas/kernel/vfio_container.hpp
@@ -47,6 +47,7 @@ public:
   void dump();
 
   void attachGroup(std::shared_ptr<Group> group);
+  std::shared_ptr<Group> getOrAttachGroup(int index);
 
   std::shared_ptr<Device> attachDevice(const std::string &name, int groupIndex);
   std::shared_ptr<Device> attachDevice(pci::Device &pdev);
@@ -65,8 +66,6 @@ public:
   bool isIommuEnabled() const { return this->hasIommu; }
 
 private:
-  std::shared_ptr<Group> getOrAttachGroup(int index);
-
   int fd;
   int version;
 


### PR DESCRIPTION
This method should not be private. Otherwise there is no method to safely attach a Group. 