### PR TITLE
VFIO-Container: Minimize default requirements

### DIFF
--- a/common/include/villas/kernel/vfio_container.hpp
+++ b/common/include/villas/kernel/vfio_container.hpp
@@ -35,8 +35,7 @@ static constexpr size_t EXTENSION_SIZE = VFIO_NOIOMMU_IOMMU + 1;
 
 class Container {
 public:
-  Container(std::vector<std::string> required_modules = {"vfio", "vfio_pci",
-                                                         "vfio_iommu_type1"});
+  Container(std::vector<std::string> required_modules = {"vfio"});
 
   // No copying allowed because we manage the vfio state in constructor and destructors
   Container(Container const &) = delete;

--- a/fpga/lib/pcie_card.cpp
+++ b/fpga/lib/pcie_card.cpp
@@ -13,6 +13,7 @@
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/node.hpp>
 #include <villas/fpga/pcie_card.hpp>
+#include <villas/kernel/kernel.hpp>
 #include <villas/kernel/pci.hpp>
 #include <villas/kernel/vfio_container.hpp>
 #include <villas/memory.hpp>
@@ -31,6 +32,10 @@ PCIeCardFactory::make(json_t *json_card, std::string card_name,
                       std::shared_ptr<kernel::vfio::Container> vc,
                       const std::filesystem::path &searchPath) {
   auto logger = getStaticLogger();
+
+  // make sure the vfio container has the required modules
+  kernel::loadModule("vfio_pcie");
+  kernel::loadModule("vfio_iommu_type1");
 
   json_t *json_ips = nullptr;
   json_t *json_paths = nullptr;


### PR DESCRIPTION
The default parameter of vfio container should be expected to work on platforms which do not support pcie. If it is required, it should be explicitly loaded.