### PR TITLE
Protobuf: Remove include dependency on generated header

### DIFF
--- a/include/villas/formats/protobuf.hpp
+++ b/include/villas/formats/protobuf.hpp
@@ -7,12 +7,7 @@
 
 #pragma once
 
-#include <cstdlib>
-
 #include <villas/format.hpp>
-
-// Generated message descriptors by protoc
-#include <villas/formats/villas.pb-c.h>
 
 namespace villas {
 namespace node {
@@ -21,9 +16,6 @@ namespace node {
 struct Sample;
 
 class ProtobufFormat : public BinaryFormat {
-
-protected:
-  enum SignalType detect(const Villas__Node__Value *val);
 
 public:
   using BinaryFormat::BinaryFormat;

--- a/lib/formats/protobuf.cpp
+++ b/lib/formats/protobuf.cpp
@@ -11,9 +11,12 @@
 #include <villas/signal.hpp>
 #include <villas/utils.hpp>
 
+// Generated message descriptors by protoc
+#include <villas/formats/villas.pb-c.h>
+
 using namespace villas::node;
 
-enum SignalType ProtobufFormat::detect(const Villas__Node__Value *val) {
+static enum SignalType detect(const Villas__Node__Value *val) {
   switch (val->value_case) {
   case VILLAS__NODE__VALUE__VALUE_F:
     return SignalType::FLOAT;


### PR DESCRIPTION
Another small change to the protobuf code. This allows easier reuse of ProtobufFormat, because we do not need to deal with including villas.pb-c.h when we only want to use the functionality of ProtobufFormat. This doesn't really have any impact on any current code as far as I can see.