### PR TITLE
ethercat: Shuffle includes to fix failing Nix builds

### DIFF
--- a/include/villas/api.hpp
+++ b/include/villas/api.hpp
@@ -14,8 +14,6 @@
 #include <list>
 #include <thread>
 
-#include <libwebsockets.h>
-
 #include <villas/common.hpp>
 #include <villas/exceptions.hpp>
 #include <villas/log.hpp>

--- a/lib/nodes/ethercat.cpp
+++ b/lib/nodes/ethercat.cpp
@@ -11,8 +11,8 @@
 
 #include <villas/exceptions.hpp>
 #include <villas/node_compat.hpp>
-#include <villas/nodes/ethercat.hpp>
 #include <villas/super_node.hpp>
+#include <villas/nodes/ethercat.hpp>
 #include <villas/utils.hpp>
 
 using namespace villas;


### PR DESCRIPTION
There seems to be a header interdependency issue with `libwebsockets.h` and `netdb.h` which are included through `include/villas/super_node.hpp` and `include/villas/api.hpp` into `lib/nodes/ethercat.cpp`. Reordering `#include <villas/super_node.hpp>` resolves the issue for now.

I also noticed that `libwebsockets.h` was included twice in `include/villas/api.hpp`.