### PR TITLE
VFIO: Add method getNumberIrqs()

### DIFF
--- a/common/include/villas/kernel/vfio_device.hpp
+++ b/common/include/villas/kernel/vfio_device.hpp
@@ -68,6 +68,8 @@ public:
 
   void setAttachedToGroup() { this->attachedToGroup = true; }
 
+  int getNumberIrqs() const { return this->info.num_irqs; }
+
 private:
   // Name of the device as listed under
   // /sys/kernel/iommu_groups/[vfio_group::index]/devices/


### PR DESCRIPTION
Add a method to get the number of interrupts on a vfio device.