### PR TITLE
node-ethercat: Fix #include after opened namespace

### DIFF
--- a/include/villas/nodes/ethercat.hpp
+++ b/include/villas/nodes/ethercat.hpp
@@ -18,21 +18,16 @@
 #include <villas/queue_signalled.h>
 #include <villas/task.hpp>
 
-namespace villas {
-namespace node {
+// Include hard-coded Ethercat Bus configuration
+#include <villas/nodes/ethercat_config.hpp>
+
+#define DEFAULT_ETHERCAT_QUEUE_LENGTH (DEFAULT_QUEUE_LENGTH * 64)
+
+namespace villas::node {
 
 // Forward declarations
 class NodeCompat;
 class SuperNode;
-
-// Include hard-coded Ethercat Bus configuration
-#include <villas/nodes/ethercat_config.hpp>
-
-extern "C" {
-#include <ecrt.h>
-}
-
-#define DEFAULT_ETHERCAT_QUEUE_LENGTH (DEFAULT_QUEUE_LENGTH * 64)
 
 // Internal data per ethercat node
 struct ethercat {
@@ -91,5 +86,4 @@ int ethercat_read(NodeCompat *n, struct Sample *const smps[], unsigned cnt);
 
 int ethercat_write(NodeCompat *n, struct Sample *const smps[], unsigned cnt);
 
-} // namespace node
-} // namespace villas
+} // namespace villas::node

--- a/include/villas/nodes/ethercat_config.hpp
+++ b/include/villas/nodes/ethercat_config.hpp
@@ -25,6 +25,8 @@
 #define ETHERCAT_PID_EL3008 0x0bc03052
 #define ETHERCAT_PID_FC1100 0x044c0c62
 
+namespace villas::node {
+
 // TODO: Make PDO entry tables configurable
 
 /* Master 0, Slave 3, "EL4038"
@@ -168,3 +170,5 @@ static ec_sync_info_t slave_4_syncs[] = {
     {2, EC_DIR_OUTPUT, 0, NULL, EC_WD_DISABLE},
     {3, EC_DIR_INPUT, 8, slave_4_pdos + 0, EC_WD_DISABLE},
     {0xff}};
+
+} // namespace villas::node


### PR DESCRIPTION
The `ethercat_config.hpp` header was included from `ethercat.hpp` after opening the `villas::node` namespace. This made all definitions originating from that header including the transitive definitions from ethercat's `ecrt.h` part of the `villas::node` namespace.

The especially problematic part was that `ecrt.h` itself has an `#include <netinet/in.h>` introduced in [1]. This caused the libc definitions for `sa_familt_t`, `sockaddr_in` and `sockaddr_in6` to be moved into the `villas::node` namespace, causing build error on recent `ethercat` versions.

[1]: https://gitlab.com/etherlab.org/ethercat/-/commit/c2f9baf96ae0c0619dead65e19d3ace0e66f031b