### PR TITLE
FPGA: Add ignorelist to prevent initialization of specific IPs

### DIFF
--- a/fpga/include/villas/fpga/card.hpp
+++ b/fpga/include/villas/fpga/card.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <set>
+#include <string>
 
 #include <villas/fpga/core.hpp>
 #include <villas/kernel/vfio_container.hpp>
@@ -36,6 +37,7 @@ public:
   MemoryManager::AddressSpaceId addrSpaceIdHostToDevice;
 
   std::list<std::shared_ptr<ip::Core>> ips;
+  std::list<std::string> ignored_ip_names;
 
   virtual ~Card();
 

--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -211,6 +211,9 @@ public:
   using plugin::Plugin::Plugin;
 
   static std::list<IpIdentifier> parseIpIdentifier(json_t *json_ips);
+  static std::list<IpIdentifier>
+  filterIps(std::list<IpIdentifier> allIps,
+            std::list<std::string> ignored_ip_names);
   static std::list<IpIdentifier> reorderIps(std::list<IpIdentifier> allIps);
   static std::list<std::shared_ptr<Core>>
   configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -67,11 +67,10 @@ CoreFactory::filterIps(std::list<IpIdentifier> allIps,
     const auto &ipName = ip.getName();
 
     if (ignored_ip_set.find(ipName) != ignored_ip_set.end()) {
-      CoreFactory::getStaticLogger()->warn(
+      CoreFactory::getStaticLogger()->info(
           "Ignoring Ip {} (explicitly on ignorelist)", ipName);
     } else {
-      filteredIps.push_back(
-          ip); // Or use `filteredIps.emplace_back(std::move(ip));` if moving is preferred.
+      filteredIps.push_back(ip);
     }
   }
 

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -57,6 +57,28 @@ std::list<IpIdentifier> CoreFactory::parseIpIdentifier(json_t *json_ips) {
 }
 
 std::list<IpIdentifier>
+CoreFactory::filterIps(std::list<IpIdentifier> allIps,
+                       std::list<std::string> ignored_ip_names) {
+  std::list<IpIdentifier> filteredIps;
+
+  std::set<std::string> ignored_ip_set(ignored_ip_names.begin(),
+                                       ignored_ip_names.end());
+  for (const auto &ip : allIps) {
+    const auto &ipName = ip.getName();
+
+    if (ignored_ip_set.find(ipName) != ignored_ip_set.end()) {
+      CoreFactory::getStaticLogger()->warn(
+          "Ignoring Ip {} (explicitly on ignorelist)", ipName);
+    } else {
+      filteredIps.push_back(
+          ip); // Or use `filteredIps.emplace_back(std::move(ip));` if moving is preferred.
+    }
+  }
+
+  return filteredIps;
+}
+
+std::list<IpIdentifier>
 CoreFactory::reorderIps(std::list<IpIdentifier> allIps) {
   // Pick out IPs to be initialized first.
   std::list<IpIdentifier> orderedIps;
@@ -314,8 +336,11 @@ std::list<std::shared_ptr<Core>> CoreFactory::make(Card *card,
   std::list<IpIdentifier> allIps =
       parseIpIdentifier(json_ips); // All IPs available in config
 
+  std::list<IpIdentifier> filteredIps = filterIps(
+      allIps, card->ignored_ip_names); // Remove ips on ignorelist in .conf
+
   std::list<IpIdentifier> orderedIps =
-      reorderIps(allIps); // IPs ordered in initialization order
+      reorderIps(filteredIps); // IPs ordered in initialization order
 
   std::list<std::shared_ptr<Core>> configuredIps =
       configureIps(orderedIps, json_ips, card); // Successfully configured IPs

--- a/fpga/lib/pcie_card.cpp
+++ b/fpga/lib/pcie_card.cpp
@@ -48,9 +48,10 @@ PCIeCardFactory::make(json_t *json_card, std::string card_name,
 
   json_error_t err;
   int ret = json_unpack_ex(
-      json_card, &err, 0, "{ s: o, s?: i, s?: b, s?: s, s?: s, s?: b, s?: o }",
+      json_card, &err, 0, "{ s: o, s?: i, s?: b, s?: s, s?: s, s?: b, s?: o, s?: o}",
       "ips", &json_ips, "affinity", &affinity, "do_reset", &do_reset, "slot",
-      &pci_slot, "id", &pci_id, "polling", &polling, "paths", &json_paths);
+      &pci_slot, "id", &pci_id, "polling", &polling, "paths", &json_paths,
+      "ignore_ips", &ignored_ips_array);
 
   if (ret != 0)
     throw ConfigError(json_card, err, "", "Failed to parse card");

--- a/fpga/lib/pcie_card.cpp
+++ b/fpga/lib/pcie_card.cpp
@@ -44,6 +44,7 @@ PCIeCardFactory::make(json_t *json_card, std::string card_name,
   int do_reset = 0;
   int affinity = 0;
   int polling = 0;
+  json_t *ignored_ips_array = nullptr;
 
   json_error_t err;
   int ret = json_unpack_ex(
@@ -62,6 +63,13 @@ PCIeCardFactory::make(json_t *json_card, std::string card_name,
   card->affinity = affinity;
   card->doReset = do_reset != 0;
   card->polling = (polling != 0);
+
+  // Parse ignored ip names to list
+  size_t index;
+  json_t *value;
+  json_array_foreach(ignored_ips_array, index, value) {
+    card->ignored_ip_names.push_back(json_string_value(value));
+  }
 
   kernel::devices::PciDevice filter = defaultFilter;
 


### PR DESCRIPTION
Adds ignorelist to .conf.

Example:
`ignore_ips = ["dino_dinoif_dac_0", "dino_dinoif_fast_nologic_0", "dino_registerif_0", "axi_iic_0"]`
