### PR TITLE
Add a matcher for OS IP devices and IPs on a FPGA

### DIFF
--- a/common/include/villas/kernel/devices/device_ip_matcher.hpp
+++ b/common/include/villas/kernel/devices/device_ip_matcher.hpp
@@ -1,5 +1,5 @@
 /* Matcher for IP devices in an OS devicetree and ips on a fpga board.
- * Matching based on adress prefix in device name and ip memoryaddress
+ * Matching based on address prefix in device name and ip memory address
  *
  * Author: Pascal Bauer <pascal.bauer@rwth-aachen.de>
  *


### PR DESCRIPTION
Match ip devices on os level with ips on the fpga based on memory address.