### PR TITLE
chore: remove catchall codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @stv0g will be requested for
-# review when someone opens a pull request.
-*       @stv0g
-
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies the following files, only the following members

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,5 @@ fpga                                                @n-eiling
 /include/villas/dumper.hpp                          @windrad6
 
 # VFIO related files
-/common/lib/kernel/pci.cpp                          @n-eiling
-/common/lib/kernel/vfi_*.cpp                        @n-eiling
-/common/include/villas/kernel/devices/*             @n-eiling
-/common/include/villas/kernel/vfio_*.hpp            @n-eiling
+/common/lib/kernel                                  @n-eiling
+/common/include/villas/kernel                       @n-eiling


### PR DESCRIPTION
@stv0g You as default code owner for everything just doesn't work anymore.
We cannot wait for 3 months for a review. I'd suggest you add yourself to parts that are very important to you.
Or do you have another idea for a solution?
