### PR TITLE
Fixes to compile in Ampere processor & Ubuntu

### DIFF
--- a/common/include/villas/tsc.hpp
+++ b/common/include/villas/tsc.hpp
@@ -32,7 +32,7 @@
 #endif
 
 #ifndef CLOCK_MONOTONIC_RAW
-#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC // Fallback for macOS/BSD
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC // Fallback for Darwin/BSD
 #endif
 
 #endif
@@ -51,7 +51,7 @@ __attribute__((unused)) static uint64_t tsc_now(struct Tsc *t) {
   return t->rdtscp_supported ? __rdtscp(&tsc_aux) : __rdtsc();
 }
 #else
-// Fallback for CLOCK_MONOTONIC_RAW (linux/BSD/mac specific)
+// Fallback for CLOCK_MONOTONIC_RAW (Linux/Darwin/BSD specific)
 __attribute__((unused)) static uint64_t tsc_now(struct Tsc *t) {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC_RAW, &ts);

--- a/common/include/villas/tsc.hpp
+++ b/common/include/villas/tsc.hpp
@@ -1,4 +1,4 @@
-/* Measure time and sleep with IA-32 time-stamp counter.
+/* Measure time and sleep with IA-32 time-stamp counter (x86) or a generic cycle-based timing.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#if !(__x86_64__ || __i386__)
-#error this header is for x86 only
-#endif
-
 #include <cinttypes>
+
+#if defined(__x86_64__) || defined(__i386__)
+
 #include <cpuid.h>
 #include <x86intrin.h>
 
@@ -24,17 +23,41 @@
 #define bit_TSC_INVARIANT (1 << 8)
 #define bit_RDTSCP (1 << 27)
 
+#else
+
+#include <time.h>
+
+#ifndef NSEC_PER_SEC
+#define NSEC_PER_SEC 1000000000L
+#endif
+
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC // Fallback for macOS/BSD
+#endif
+
+#endif
+
 struct Tsc {
   uint64_t frequency;
-
+#if defined(__x86_64__) || defined(__i386__)
   bool rdtscp_supported;
   bool is_invariant;
+#endif
 };
 
+#if defined(__x86_64__) || defined(__i386__)
 __attribute__((unused)) static uint64_t tsc_now(struct Tsc *t) {
   uint32_t tsc_aux;
   return t->rdtscp_supported ? __rdtscp(&tsc_aux) : __rdtsc();
 }
+#else
+// Fallback for CLOCK_MONOTONIC_RAW (linux/BSD/mac specific)
+__attribute__((unused)) static uint64_t tsc_now(struct Tsc *t) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  return (ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec) * t->frequency / NSEC_PER_SEC;
+}
+#endif
 
 int tsc_init(struct Tsc *t) __attribute__((warn_unused_result));
 

--- a/common/lib/CMakeLists.txt
+++ b/common/lib/CMakeLists.txt
@@ -33,10 +33,6 @@ add_library(villas-common SHARED
     version.cpp
 )
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    target_sources(villas-common PRIVATE tsc.cpp)
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     target_sources(villas-common PRIVATE
         kernel/devices/ip_device.cpp
@@ -46,6 +42,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
         kernel/vfio_device.cpp
         kernel/vfio_group.cpp
         kernel/vfio_container.cpp
+        tsc.cpp
     )
 endif()
 

--- a/common/lib/tsc.cpp
+++ b/common/lib/tsc.cpp
@@ -40,11 +40,6 @@ int tsc_init(struct Tsc *t) {
       return ret;
 #endif
   }
-#elif defined(__aarch64__)
-  // Read counter frequency from system register
-  uint64_t cntfrq;
-  asm volatile("mrs %0, cntfrq_el0" : "=r"(cntfrq));
-  t->frequency = cntfrq;
 #else
 #ifdef __linux__
   int ret = kernel::get_cpu_frequency(&t->frequency);

--- a/common/lib/tsc.cpp
+++ b/common/lib/tsc.cpp
@@ -5,7 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <villas/kernel/kernel.hpp>
 #include <villas/tsc.hpp>
+
+using namespace villas;
 
 int tsc_init(struct Tsc *t) {
 #if defined(__x86_64__) || defined(__i386__)

--- a/common/lib/tsc.cpp
+++ b/common/lib/tsc.cpp
@@ -52,7 +52,10 @@ int tsc_init(struct Tsc *t) {
     return ret;
 #endif
 #endif
-  return (int)(t->frequency);
+  if (t->frequency)
+    return 0; // Frequency determined with success
+  else
+    return -1;
 }
 
 uint64_t tsc_rate_to_cycles(struct Tsc *t, double rate) {

--- a/common/tests/unit/kernel.cpp
+++ b/common/tests/unit/kernel.cpp
@@ -17,20 +17,18 @@ using namespace villas::kernel;
 // cppcheck-suppress unknownMacro
 TestSuite(kernel, .description = "Kernel features");
 
-#if defined(__x86_64__) || defined(__i386__)
 #define PAGESIZE (1 << 12)
 #define CACHELINESIZE 64
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 #define HUGEPAGESIZE (1 << 21)
 #elif defined(__i386__)
 #define HUGEPAGESIZE (1 << 22)
-#endif
 #else
 #error "Unsupported architecture"
 #endif
 
-// This test is not portable, but we currently support x86 only
+// This test is not portable.
 Test(kernel, sizes) {
   int sz;
 

--- a/packaging/deps.sh
+++ b/packaging/deps.sh
@@ -354,7 +354,7 @@ fi
 # Build & Install redis++
 if ! pkg-config "redis++ >= 1.2.3" && \
     should_build "redis++" "for the redis node-type"; then
-    git clone ${GIT_OPTS} --branch 1.3.7 https://github.com/sewenew/redis-plus-plus.git
+    git clone ${GIT_OPTS} --branch 1.3.8 https://github.com/sewenew/redis-plus-plus.git
     mkdir -p redis-plus-plus/build
     pushd redis-plus-plus/build
 
@@ -424,6 +424,8 @@ if ! pkg-config "nice >= 0.1.16" && \
         if ! command -v meson; then
             python3 -m venv venv
             . venv/bin/activate
+            python3 -m pip install --upgrade pip setuptools
+
 
             # Note: meson 0.61.5 is the latest version which supports the CMake version on the target
             pip3 install meson==0.61.5

--- a/packaging/docker/Dockerfile.ubuntu
+++ b/packaging/docker/Dockerfile.ubuntu
@@ -58,7 +58,7 @@ RUN apt-get update && \
 		libnice-dev \
 		libmodbus-dev \
 		libre2-dev \
-		libglib2.0-0 libglib2.0-dev \
+		libglib2.0-dev \
 		libcriterion-dev
 
 # Add local and 64-bit locations to linker paths

--- a/packaging/docker/Dockerfile.ubuntu
+++ b/packaging/docker/Dockerfile.ubuntu
@@ -6,7 +6,7 @@
 
 # You can choose between Debian and Ubuntu here
 ARG DISTRO=ubuntu
-ARG UBUNTU_VERSION=22.04
+ARG UBUNTU_VERSION=24.04
 ARG DISTRO=${DISTRO}
 
 FROM ${DISTRO}:${UBUNTU_VERSION} AS dev
@@ -24,7 +24,10 @@ RUN apt-get update && \
 		texinfo git curl tar wget diffutils \
 		flex bison \
 		protobuf-compiler protobuf-c-compiler \
-		clang-format clangd
+		clang-format clangd \
+		python3-venv \
+		ninja-build mercurial \
+		xmlto udev
 
 # Dependencies
 RUN apt-get update && \
@@ -53,7 +56,10 @@ RUN apt-get update && \
 		liblua5.3-dev \
 		libhiredis-dev \
 		libnice-dev \
-		libmodbus-dev
+		libmodbus-dev \
+		libre2-dev \
+		libglib2.0-0 libglib2.0-dev \
+		libcriterion-dev
 
 # Add local and 64-bit locations to linker paths
 ENV echo /usr/local/lib >> /etc/ld.so.conf && \
@@ -93,7 +99,7 @@ LABEL \
 	org.label-schema.vendor="Institute for Automation of Complex Power Systems, RWTH Aachen University" \
 	org.label-schema.author.name="Steffen Vogel" \
 	org.label-schema.author.email="post@steffenvogel.de" \
-	org.label-schema.description="A image containing all build-time dependencies for VILLASnode based on Fedora" \
+	org.label-schema.description="An image containing all build-time dependencies for VILLASnode based on Ubuntu" \
 	org.label-schema.url="http://fein-aachen.org/projects/villas-framework/" \
 	org.label-schema.vcs-url="https://git.rwth-aachen.de/acs/public/villas/node" \
 	org.label-schema.usage="https://villas.fein-aachen.org/doc/node-installation.html#node-installation-docker"

--- a/tests/unit/queue.cpp
+++ b/tests/unit/queue.cpp
@@ -205,6 +205,7 @@ void *producer_consumer_many(void *ctx) {
 }
 #endif // _POSIX_BARRIERS
 
+// cppcheck-suppress unknownMacro
 Test(queue, single_threaded, .init = init_memory) {
   int ret;
   struct param p;
@@ -226,6 +227,7 @@ Test(queue, single_threaded, .init = init_memory) {
 }
 
 #if defined(_POSIX_BARRIERS) && _POSIX_BARRIERS > 0
+// cppcheck-suppress unknownMacro
 ParameterizedTestParameters(queue, multi_threaded) {
   static struct param params[] = {{.iter_count = 1 << 12,
                                    .queue_size = 1 << 9,
@@ -261,6 +263,7 @@ ParameterizedTestParameters(queue, multi_threaded) {
   return cr_make_param_array(struct param, params, ARRAY_LEN(params));
 }
 
+// cppcheck-suppress unknownMacro
 ParameterizedTest(struct param *p, queue, multi_threaded, .timeout = 20,
                   .init = init_memory) {
   int ret, cycpop;
@@ -319,6 +322,7 @@ ParameterizedTest(struct param *p, queue, multi_threaded, .timeout = 20,
 }
 #endif // _POSIX_BARRIERS
 
+// cppcheck-suppress unknownMacro
 Test(queue, init_destroy, .init = init_memory) {
   int ret;
   struct CQueue q;

--- a/tests/unit/queue.cpp
+++ b/tests/unit/queue.cpp
@@ -62,8 +62,14 @@ uint64_t thread_get_id() {
   return -1;
 }
 
-// Sleep, do nothing
-__attribute__((always_inline)) static inline void nop() { __asm__("rep nop;"); }
+// Sleep, do nothing (Architecture-Specific)
+__attribute__((always_inline)) static inline void nop() {
+#if defined(__aarch64__)
+  __asm__ volatile("yield"); /// ARM equivalent of rep nop.
+#else
+  __asm__ volatile("rep nop"); /// x86 and most other architectures use rep nop.
+#endif
+}
 
 static void *producer(void *ctx) {
   int ret;


### PR DESCRIPTION
This PR has the following goals:
- Compile using Ubuntu 24.04
- Compile in ARM64 architecture (aarch64).

**Changelog**
- On the script for dependencies: 
    - Repository updated for redis++, version bump 1.3.7 -> 1.3.8 to fix compilation issue.
    - Failure for distutils, installing now setuptools in the virtual environment for compilation of libnice.
- In the documentation and docker container for Ubuntu:
    -  Add dependencies needed for libnice and libdatachannel compilation.
 - Timestamp counter (TSC) and tests for Kernel and Queue updated for compatibility:
     - Ensured nop() function works correctly on both x86 and ARM. Replaced rep nop with yield on ARM (__aarch64__) to ensure cross-platform compatibility. 
     - Adapt tsc_init to support compatibility and obtain data from the kernel call as a fallback case.
     - Move the tsc.cpp file to the linux-required section of CMakeLists.