### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,7 @@ fpga                                                @n-eiling
 
 # VFIO related files
 /common/lib/kernel/pci.cpp                          @n-eiling
-/common/lib/kernel/vfi_*.cpp                        @n-eiling
+/common/lib/kernel/vfio_*.cpp                       @n-eiling
+/common/lib/kernel/devices/*                        @n-eiling
 /common/include/villas/kernel/devices/*             @n-eiling
 /common/include/villas/kernel/vfio_*.hpp            @n-eiling


### PR DESCRIPTION
Fix typo in CODEOWNERS and add n-eiling as CODEOWNER of /common/villas/kernel/devices