### PR TITLE
fix #832: Set CI timeout to 15 min

### DIFF
--- a/tools/integration-tests.sh
+++ b/tools/integration-tests.sh
@@ -22,7 +22,7 @@ VERBOSE=${VERBOSE:-0}
 FAIL_FAST=${FAIL_FAST:-0}
 FILTER=${FILTER:-'*'}
 NUM_SAMPLES=${NUM_SAMPLES:-100}
-TIMEOUT=${TIMEOUT:-1m}
+TIMEOUT=${TIMEOUT:-15m}
 
 # Parse command line arguments
 while getopts ":f:l:t:vg" OPT; do


### PR DESCRIPTION
fix #832

The pipeline integration test keeps failing due to a timeout (caused by slow runner).
I increased the default timeout, however environment variables can override the value.
