### PR TITLE
refactor: move singular vfio device requirement to PCIeCard

### DIFF
--- a/fpga/include/villas/fpga/card.hpp
+++ b/fpga/include/villas/fpga/card.hpp
@@ -25,7 +25,6 @@ public:
 
   std::string name; // The name of the FPGA card
   std::shared_ptr<kernel::vfio::Container> vfioContainer;
-  std::shared_ptr<kernel::vfio::Device> vfioDevice;
 
   // Slave address space ID to access the PCIe address space from the
   // FPGA

--- a/fpga/include/villas/fpga/ips/intc.hpp
+++ b/fpga/include/villas/fpga/ips/intc.hpp
@@ -11,6 +11,7 @@
 #include <xilinx/xintc.h>
 
 #include <villas/fpga/core.hpp>
+#include <villas/kernel/vfio_device.hpp>
 
 namespace villas {
 namespace fpga {
@@ -39,6 +40,8 @@ public:
 
 private:
   static constexpr char registerMemory[] = "reg0";
+
+  std::shared_ptr<villas::kernel::vfio::Device> vfioDevice = nullptr;
 
   std::list<MemoryBlockName> getMemoryBlocks() const {
     return {registerMemory};

--- a/fpga/include/villas/fpga/pcie_card.hpp
+++ b/fpga/include/villas/fpga/pcie_card.hpp
@@ -56,6 +56,7 @@ public:         // TODO: make this private
   int affinity; // Affinity for MSI interrupts
 
   std::shared_ptr<kernel::devices::PciDevice> pdev; // PCI device handle
+  std::shared_ptr<kernel::vfio::Device> vfioDevice;
 
 protected:
   Logger getLogger() const { return villas::Log::get(name); }

--- a/fpga/lib/ips/intc.cpp
+++ b/fpga/lib/ips/intc.cpp
@@ -22,17 +22,20 @@ using namespace villas::fpga::ip;
 InterruptController::~InterruptController() {}
 
 bool InterruptController::stop() {
-  return card->vfioDevice->pciMsiDeinit(this->efds) > 0;
+  return this->vfioDevice->pciMsiDeinit(this->efds) > 0;
 }
 
 bool InterruptController::init() {
   const uintptr_t base = getBaseAddr(registerMemory);
 
-  num_irqs = card->vfioDevice->pciMsiInit(efds);
+  PCIeCard *pciecard = dynamic_cast<PCIeCard *>(card);
+  this->vfioDevice = pciecard->vfioDevice;
+
+  num_irqs = this->vfioDevice->pciMsiInit(efds);
   if (num_irqs < 0)
     return false;
 
-  if (not card->vfioDevice->pciMsiFind(nos)) {
+  if (not this->vfioDevice->pciMsiFind(nos)) {
     return false;
   }
 

--- a/fpga/lib/ips/pcie.cpp
+++ b/fpga/lib/ips/pcie.cpp
@@ -24,9 +24,11 @@ bool AxiPciExpressBridge::init() {
   // address space we can use for translation -> error
   card->addrSpaceIdHostToDevice = busMasterInterfaces.at(getAxiInterfaceName());
 
+  PCIeCard *pciecard = dynamic_cast<PCIeCard *>(card);
+
   // Map PCIe BAR0 via VFIO
   const void *bar0_mapped =
-      card->vfioDevice->regionMap(VFIO_PCI_BAR0_REGION_INDEX);
+      pciecard->vfioDevice->regionMap(VFIO_PCI_BAR0_REGION_INDEX);
   if (bar0_mapped == MAP_FAILED) {
     logger->error("Failed to mmap() BAR0");
     return false;
@@ -34,7 +36,7 @@ bool AxiPciExpressBridge::init() {
 
   // Determine size of BAR0 region
   const size_t bar0_size =
-      card->vfioDevice->regionGetSize(VFIO_PCI_BAR0_REGION_INDEX);
+      pciecard->vfioDevice->regionGetSize(VFIO_PCI_BAR0_REGION_INDEX);
 
   // Create a mapping from process address space to the FPGA card via vfio
   mm.createMapping(reinterpret_cast<uintptr_t>(bar0_mapped), 0, bar0_size,

--- a/lib/nodes/fpga.cpp
+++ b/lib/nodes/fpga.cpp
@@ -23,6 +23,7 @@
 #include <villas/fpga/ips/dino.hpp>
 #include <villas/fpga/ips/register.hpp>
 #include <villas/fpga/ips/switch.hpp>
+#include <villas/fpga/pcie_card.hpp>
 #include <villas/fpga/utils.hpp>
 
 using namespace villas;
@@ -367,7 +368,8 @@ int FpgaNode::slowWrite(Sample *smps[], unsigned cnt) {
 
 std::vector<int> FpgaNode::getPollFDs() {
   if (!lowLatencyMode && card && !card->polling) {
-    return card->vfioDevice->getEventfdList();
+    std::shared_ptr<PCIeCard> pciecard = std::dynamic_pointer_cast<PCIeCard>(card);
+    return pciecard->vfioDevice->getEventfdList();
   } else {
     return {};
   }


### PR DESCRIPTION
Pcie card works with exactly one vfio device.
The new improved design for platform cards will any number of vfio devices.