### PR TITLE
Fix: fpga wrong dino ip name, move do reset of card to parent

### DIFF
--- a/fpga/include/villas/fpga/card.hpp
+++ b/fpga/include/villas/fpga/card.hpp
@@ -22,7 +22,7 @@ namespace fpga {
 class Card {
 public:
   bool polling;
-
+  bool doReset;     // Reset VILLASfpga during startup?
   std::string name; // The name of the FPGA card
   std::shared_ptr<kernel::vfio::Container> vfioContainer;
 

--- a/fpga/include/villas/fpga/pcie_card.hpp
+++ b/fpga/include/villas/fpga/pcie_card.hpp
@@ -52,7 +52,6 @@ public:
   void dump() {}
 
 public:         // TODO: make this private
-  bool doReset; // Reset VILLASfpga during startup?
   int affinity; // Affinity for MSI interrupts
 
   std::shared_ptr<kernel::devices::PciDevice> pdev; // PCI device handle

--- a/lib/nodes/fpga.cpp
+++ b/lib/nodes/fpga.cpp
@@ -80,7 +80,7 @@ int FpgaNode::prepare() {
       card->lookupIp(fpga::Vlnv("xilinx.com:module_ref:registerif:")));
 
   if (reg != nullptr &&
-      card->lookupIp(fpga::Vlnv("xilinx.com:module_ref:dinoif_fast:"))) {
+      card->lookupIp(fpga::Vlnv("xilinx.com:module_ref:dinoif_adc:"))) {
     fpga::ip::DinoAdc::setRegisterConfigTimestep(reg, timestep);
   } else {
     logger->warn("No DinoAdc or no Register found on FPGA.");


### PR DESCRIPTION
The ip name of dinoif_fast was corrected to dinoif_adc.
The member doReset of pciecard was moved to parent class card.