### PR TITLE
Python-Wrapper commits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,6 +170,7 @@ test:unit:
   script:
     - cmake -S . -B build ${CMAKE_OPTS}
     - cmake --build build ${CMAKE_BUILD_OPTS} --target run-unit-tests run-unit-tests-common
+    - cmake --build build ${CMAKE_BUILD_OPTS} --target python-wrapper-tests
   needs:
     - job: "build:source: [fedora]"
       artifacts: true

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -5,4 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(opal-rt/rtlab-asyncip)
+add_subdirectory(python-wrapper)
 add_subdirectory(shmem)

--- a/clients/python-wrapper/CMakeLists.txt
+++ b/clients/python-wrapper/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Python-wrapper CMakeLists.
+#
+# Author: Kevin Vu te Laar <vu.te@rwth-aachen.de>
+# SPDX-FileCopyrightText: 2014-2025 Institute for Automation of Complex Power Systems, RWTH Aachen University
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.15...3.29)
 project(villas-python-wrapper LANGUAGES CXX)
 

--- a/clients/python-wrapper/CMakeLists.txt
+++ b/clients/python-wrapper/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(villas-python-wrapper LANGUAGES CXX)
+
+set(PYBIND11_FINDPYTHON ON)
+find_package(pybind11 CONFIG OPTIONAL)
+
+if(pybind11_FOUND)
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_path('stdlib') + '/lib-dynload')"
+    OUTPUT_VARIABLE PYTHON_LIB_DYNLOAD_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  message(STATUS "Found Python version: ${Python_VERSION}")
+  message(STATUS "Python major version: ${Python_VERSION_MAJOR}")
+  message(STATUS "Python minor version: ${Python_VERSION_MINOR}")
+  message(STATUS "Python .so install directory: ${PYTHON_LIB_DYNLOAD_DIR}")
+
+  pybind11_add_module(villas_node villas-python-wrapper.cpp)
+  target_link_libraries(villas_node PUBLIC villas)
+
+  install(
+    TARGETS villas_node
+    COMPONENT lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${PYTHON_LIB_DYNLOAD_DIR}
+  )
+else()
+  message(STATUS "pybind11 not found. Skipping Python wrapper build.")
+endif()

--- a/clients/python-wrapper/CMakeLists.txt
+++ b/clients/python-wrapper/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15...3.29)
 project(villas-python-wrapper LANGUAGES CXX)
 
 set(PYBIND11_FINDPYTHON ON)
-find_package(pybind11 CONFIG OPTIONAL)
+find_package(pybind11 CONFIG)
 
 if(pybind11_FOUND)
   find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
@@ -18,11 +18,12 @@ if(pybind11_FOUND)
   message(STATUS "Python minor version: ${Python_VERSION_MINOR}")
   message(STATUS "Python .so install directory: ${PYTHON_LIB_DYNLOAD_DIR}")
 
-  pybind11_add_module(villas_node villas-python-wrapper.cpp)
-  target_link_libraries(villas_node PUBLIC villas)
+  pybind11_add_module(python-wrapper villas-python-wrapper.cpp)
+  set_target_properties(python-wrapper PROPERTIES OUTPUT_NAME villas_node)
+  target_link_libraries(python-wrapper PUBLIC villas)
 
   install(
-    TARGETS villas_node
+    TARGETS python-wrapper
     COMPONENT lib
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${PYTHON_LIB_DYNLOAD_DIR}

--- a/clients/python-wrapper/villas-python-wrapper.cpp
+++ b/clients/python-wrapper/villas-python-wrapper.cpp
@@ -1,0 +1,235 @@
+#include <jansson.h>
+#include <pybind11/pybind11.h>
+#include <uuid/uuid.h>
+#include <villas/node.hpp>
+#include <villas/sample.hpp>
+extern "C" {
+  #include <villas/node.h>
+}
+
+namespace py = pybind11;
+
+class Array {
+  public:
+    Array(unsigned int len) {
+      smps = new vsample *[len]();
+      this->len = len;
+    }
+    ~Array() {
+      for(unsigned int i = 0; i < len; ++i) {
+        sample_decref(smps[i]);
+        smps[i] = nullptr;
+      }
+      delete[] smps;
+    }
+
+    vsample * &operator[](unsigned int idx) {
+      return smps[idx];
+    }
+
+    vsample * &operator[](unsigned int idx) const {
+      return smps[idx];
+    }
+
+    vsample ** get_smps() {
+      return smps;
+    }
+
+    unsigned int size() const {
+      return len;
+    }
+
+  private:
+    vsample **smps;
+    unsigned int len;
+};
+
+//pybind11 can not deal with (void **) as function input parameters,
+//therefore we have to cast a simple (void *) pointer to the corresponding type
+//
+//wrapper bindings, sorted alphabetically
+// @param villas_node   Name of the module to be bound
+// @param m             Access variable for modifying the module code
+//
+PYBIND11_MODULE(villas_node, m) {
+  m.def("memory_init", &memory_init);
+
+  m.def("node_check", [](void *n) -> int {
+        return node_check((vnode *)n);
+      });
+
+  m.def("node_destroy", [](void *n) -> int {
+        return node_destroy((vnode *)n);
+      });
+
+  m.def("node_details", [](void *n) -> const char * {
+        return node_details((vnode *)n);
+      },
+      py::return_value_policy::copy);
+
+  m.def("node_input_signals_max_cnt", [](void *n) -> unsigned {
+        return node_input_signals_max_cnt((vnode *)n);
+      });
+
+  m.def("node_is_enabled", [](void *n) -> bool {
+        return node_is_enabled((const vnode*)n);
+      });
+
+  m.def("node_is_valid_name", [](const char *name) -> bool {
+        return node_is_valid_name(name);
+      });
+
+  m.def("node_name", [](void *n) -> const char * {
+        return node_name((vnode *)n);
+      },
+      py::return_value_policy::copy);
+
+  m.def("node_name_full", [](void *n) -> const char * {
+        return node_name_full((vnode *)n);
+      },
+      py::return_value_policy::copy);
+
+  m.def("node_name_short", [](void *n) -> const char * {
+        return node_name_short((vnode *)n);
+      },
+      py::return_value_policy::copy);
+
+  m.def("node_netem_fds", [](void *n, int fds[]) -> int {
+        return node_netem_fds((vnode *)n, fds);
+      });
+
+  m.def("node_new", [](const char *id_str, const char *json_str) -> vnode * {
+        json_error_t err;
+        uuid_t id;
+
+        uuid_parse(id_str, id);
+        auto *json = json_loads(json_str, 0, &err);
+
+        void *it = json_object_iter(json);
+        json_t *inner = json_object_iter_value(it);
+
+        if (json_is_object(inner)) { // create node with name
+          return (vnode *)villas::node::NodeFactory::make(json_object_iter_value(it), id, json_object_iter_key(it));
+        }
+        else { // create node without name
+          char* capi_str = json_dumps(json, 0);
+          auto ret = node_new(id_str, capi_str);
+
+          free(capi_str);
+          return ret;
+        }
+      },
+      py::return_value_policy::reference);
+
+  m.def("node_output_signals_max_cnt", [](void *n) -> unsigned {
+        return node_output_signals_max_cnt((vnode *)n);
+      });
+
+  m.def("node_pause", [](void *n) -> int {
+        return node_pause((vnode *)n);
+      });
+
+  m.def("node_poll_fds", [](void *n, int fds[]) -> int {
+        return node_poll_fds((vnode *)n, fds);
+      });
+
+  m.def("node_prepare", [](void *n) -> int {
+        return node_prepare((vsample *)n);
+      });
+
+  m.def("node_read", [](void *n, Array &a, unsigned cnt) -> int {
+        return node_read((vnode *)n, a.get_smps(), cnt);
+      });
+
+  m.def("node_restart", [](void *n) -> int {
+        return node_restart((vnode *)n);
+      });
+
+  m.def("node_resume", [](void *n) -> int {
+        return node_resume((vnode *)n);
+      });
+
+  m.def("node_reverse", [](void *n) -> int {
+        return node_reverse((vnode *)n);
+      });
+
+  m.def("node_start", [](void *n) -> int {
+        return node_start((vnode *)n);
+      });
+
+  m.def("node_stop", [](void *n) -> int {
+        return node_stop((vnode *)n);
+      });
+
+  m.def("node_to_json", [](void *n) -> py::str {
+        auto json = reinterpret_cast<villas::node::Node *>(n)->toJson();
+        char* json_str = json_dumps(json, 0);
+        auto py_str = py::str(json_str);
+
+        json_decref(json);
+        free(json_str);
+
+        return py_str;
+      });
+
+  m.def("node_to_json_str", [](void *n) -> py::str {
+        auto json = reinterpret_cast<villas::node::Node *>(n)->toJson();
+        char* json_str = json_dumps(json, 0);
+        auto py_str = py::str(json_str);
+
+        json_decref(json);
+        free(json_str);
+
+        return py_str;
+      });
+
+  m.def("node_write", [](void *n, Array &a, unsigned cnt) -> int {
+        return node_write((vnode *)n, a.get_smps(), cnt);
+      });
+
+  m.def("smps_array", [](unsigned int len) -> Array* {
+        return new Array(len);
+      },
+      py::return_value_policy::take_ownership);
+
+  m.def("sample_alloc", [](unsigned int len) -> vsample * {
+        return sample_alloc(len);
+      });
+
+  // Decrease reference count and release memory if last reference was held.
+  m.def("sample_decref", [](void *smps) -> void {
+        auto smp = (vsample **)smps;
+        sample_decref(*smp);
+      });
+
+  m.def("sample_length", [](void *smp) -> unsigned {
+        return sample_length((vsample *)smp);
+      });
+
+  m.def("sample_pack", &sample_pack, py::return_value_policy::reference);
+
+  m.def("sample_unpack", [](void *smp, unsigned *seq, struct timespec *ts_origin,
+                            struct timespec *ts_received, int *flags, unsigned *len,
+                            double *values) -> void {
+        return sample_unpack((vsample *)smp, seq, ts_origin, ts_received, flags, len, values);
+      },
+      py::return_value_policy::reference);
+
+  py::class_<Array>(m, "SamplesArray")
+    .def(py::init<unsigned int>(), py::arg("len"))
+    .def("__getitem__", [](Array &a, unsigned int idx) {
+        if (idx >= a.size()) {
+          throw py::index_error("Index out of bounds");
+        }
+        return a[idx];
+      })
+    .def("__setitem__", [](Array &a, unsigned int idx, void *smp) {
+        if (idx >= a.size()) {
+          throw py::index_error("Index out of bounds");
+        }
+        if (a[idx]) {
+          sample_decref(a[idx]);
+        }
+        a[idx] = (vsample *)smp;
+      });
+}

--- a/clients/python-wrapper/villas-python-wrapper.cpp
+++ b/clients/python-wrapper/villas-python-wrapper.cpp
@@ -1,8 +1,16 @@
+/* Python-wrapper.
+ *
+ * Author: Kevin Vu te Laar <vu.te@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2025 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <jansson.h>
 #include <pybind11/pybind11.h>
 #include <uuid/uuid.h>
 #include <villas/node.hpp>
 #include <villas/sample.hpp>
+
 extern "C" {
   #include <villas/node.h>
 }
@@ -44,13 +52,13 @@ class Array {
     unsigned int len;
 };
 
-//pybind11 can not deal with (void **) as function input parameters,
-//therefore we have to cast a simple (void *) pointer to the corresponding type
-//
-//wrapper bindings, sorted alphabetically
-// @param villas_node   Name of the module to be bound
-// @param m             Access variable for modifying the module code
-//
+/* pybind11 can not deal with (void **) as function input parameters,
+ * therefore we have to cast a simple (void *) pointer to the corresponding type
+ *
+ * wrapper bindings, sorted alphabetically
+ * @param villas_node   Name of the module to be bound
+ * @param m             Access variable for modifying the module code
+ */
 PYBIND11_MODULE(villas_node, m) {
   m.def("memory_init", &memory_init);
 

--- a/lib/node.cpp
+++ b/lib/node.cpp
@@ -437,7 +437,7 @@ Node *NodeFactory::make(json_t *json, const uuid_t &id,
   std::string type;
   Node *n;
 
-  if (json_is_object(json))
+  if (!json_is_object(json))
     throw ConfigError(json, "node-config-node",
                       "Node configuration must be an object");
 

--- a/packaging/docker/Dockerfile.debian
+++ b/packaging/docker/Dockerfile.debian
@@ -51,7 +51,10 @@ RUN apt-get update && \
 		liblua5.3-dev \
 		libhiredis-dev \
 		libnice-dev \
-		libmodbus-dev
+		libmodbus-dev \
+		python3 \
+		python3-dev \
+		python3-pybind11
 
 # Add local and 64-bit locations to linker paths
 ENV echo /usr/local/lib >> /etc/ld.so.conf && \

--- a/packaging/docker/Dockerfile.debian-multiarch
+++ b/packaging/docker/Dockerfile.debian-multiarch
@@ -58,7 +58,10 @@ RUN apt-get update && \
 		libusb-1.0-0-dev:${ARCH} \
 		liblua5.3-dev:${ARCH} \
 		libhiredis-dev:${ARCH} \
-		libmodbus-dev:${ARCH}
+		libmodbus-dev:${ARCH} \
+		python3:${ARCH} \
+		python3-dev:${ARCH} \
+		python3-pybind11:${ARCH}
 
 # Add local and 64-bit locations to linker paths
 ENV echo /usr/local/lib >> /etc/ld.so.conf && \

--- a/packaging/docker/Dockerfile.fedora
+++ b/packaging/docker/Dockerfile.fedora
@@ -64,7 +64,8 @@ RUN dnf -y install \
 	lua-devel \
 	hiredis-devel \
 	libnice-devel \
-	libmodbus-devel
+	libmodbus-devel \
+	pybind11-devel
 
 # Add local and 64-bit locations to linker paths
 RUN echo /usr/local/lib   >> /etc/ld.so.conf && \

--- a/packaging/docker/Dockerfile.rocky
+++ b/packaging/docker/Dockerfile.rocky
@@ -25,7 +25,8 @@ RUN dnf --allowerasing -y install \
 	flex bison \
 	texinfo git curl tar \
 	protobuf-compiler protobuf-c-compiler \
-	clang-tools-extra
+	clang-tools-extra \
+  python python-devel
 
 # Dependencies
 RUN dnf -y install \
@@ -48,7 +49,8 @@ RUN dnf -y install \
 	lua-devel \
 	hiredis-devel \
 	libnice-devel \
-	libmodbus-devel
+	libmodbus-devel \
+	pybind11-devel
 
 # Add local and 64-bit locations to linker paths
 ENV echo /usr/local/lib >> /etc/ld.so.conf && \

--- a/packaging/docker/Dockerfile.rocky
+++ b/packaging/docker/Dockerfile.rocky
@@ -26,7 +26,7 @@ RUN dnf --allowerasing -y install \
 	texinfo git curl tar \
 	protobuf-compiler protobuf-c-compiler \
 	clang-tools-extra \
-  python python-devel
+	python python-devel
 
 # Dependencies
 RUN dnf -y install \

--- a/packaging/docker/Dockerfile.ubuntu
+++ b/packaging/docker/Dockerfile.ubuntu
@@ -59,7 +59,10 @@ RUN apt-get update && \
 		libmodbus-dev \
 		libre2-dev \
 		libglib2.0-dev \
-		libcriterion-dev
+		libcriterion-dev \
+		python3 \
+		python3-dev \
+		python3-pybind11
 
 # Add local and 64-bit locations to linker paths
 ENV echo /usr/local/lib >> /etc/ld.so.conf && \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -35,5 +35,13 @@ add_custom_target(run-unit-tests
     USES_TERMINAL
 )
 
+add_custom_target(run-python-wrapper-tests
+    COMMAND
+        ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tests/unit/python_wrapper.py
+    DEPENDS
+        python-wrapper
+    USES_TERMINAL
+)
+
 add_dependencies(tests unit-tests)
-add_dependencies(run-tests run-unit-tests)
+add_dependencies(run-tests run-unit-tests run-python-wrapper-tests)

--- a/tests/unit/python_wrapper.py
+++ b/tests/unit/python_wrapper.py
@@ -1,3 +1,9 @@
+"""
+Author: Kevin Vu te Laar <vu.te@rwth-aachen.de>
+SPDX-FileCopyrightText: 2014-2025 Institute for Automation of Complex Power Systems, RWTH Aachen University
+SPDX-License-Identifier: Apache-2.0
+"""  # noqa: E501
+
 import json
 import re
 import unittest

--- a/tests/unit/python_wrapper.py
+++ b/tests/unit/python_wrapper.py
@@ -1,0 +1,295 @@
+import json
+import re
+import unittest
+import uuid
+import villas_node as vn
+
+class SimpleWrapperTests(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            self.node_uuid = str(uuid.uuid4())
+            self.config = json.dumps(test_node_config, indent=2)
+            self.test_node = vn.node_new(self.node_uuid, self.config)
+        except Exception as e:
+            self.fail(f"new_node err: {e}")
+
+    def test_activity_changes(self):
+        try:
+            vn.node_check(self.test_node)
+            vn.node_prepare(self.test_node)
+            # starting twice
+            self.assertEqual(0, vn.node_start(self.test_node))
+            # with self.assertRaises((AssertionError, RuntimeError)):
+            #     vn.node_start(self.test_node)
+
+            # check if the node is running
+            self.assertTrue(vn.node_is_enabled(self.test_node))
+
+            # pausing twice
+            self.assertEqual(0, vn.node_pause(self.test_node))
+            self.assertEqual(-1, vn.node_pause(self.test_node))
+
+            # resuming
+            self.assertEqual(0, vn.node_resume(self.test_node))
+
+            # stopping twice
+            self.assertEqual(0, vn.node_stop(self.test_node))
+            # self.assertEqual(-1, vn.node_stop(self.test_node))
+
+            # # restarting
+            # vn.node_restart(self.test_node)
+
+            # check if everything still works after restarting
+            # vn.node_pause(self.test_node)
+            # vn.node_resume(self.test_node)
+            # vn.node_stop(self.test_node)
+
+            # terminating the node
+            vn.node_destroy(self.test_node)
+        except Exception as e:
+            self.fail(f" err: {e}")
+
+    def test_details(self):
+        try:
+            # remove color codes before checking for equality
+            self.assertEqual("test_node(socket)", re.sub(r'\x1b\[[0-9;]*m', '', vn.node_name(self.test_node)))
+
+            # node_name_short is bugged
+            # self.assertEqual('', vn.node_name_short(self.test_node))
+            self.assertEqual(
+                vn.node_name(self.test_node) +
+                ': uuid=' +
+                self.node_uuid +
+                ', #in.signals=1/1, #in.hooks=0, #out.hooks=0, in.vectorize=1, out.vectorize=1, out.netem=no, layer=udp, in.address=0.0.0.0:12000, out.address=127.0.0.1:12001',
+                vn.node_name_full(self.test_node)
+            )
+
+            self.assertEqual(
+                'layer=udp, in.address=0.0.0.0:12000, out.address=127.0.0.1:12001',
+                vn.node_details(self.test_node)
+            )
+
+            self.assertEqual(1, vn.node_input_signals_max_cnt(self.test_node))
+            self.assertEqual(0, vn.node_output_signals_max_cnt(self.test_node))
+        except Exception as e:
+            self.fail(f" err: {e}")
+
+    # Test whether or not the json object is created by the wrapper and the <json> module
+    def test_json_obj(self):
+        try:
+            node_config = vn.node_to_json(self.test_node)
+            node_config_str = json.dumps(node_config)
+            node_config_parsed = json.loads(node_config_str)
+
+            self.assertEqual(node_config, node_config_parsed)
+        except Exception as e:
+            self.fail(f" err: {e}")
+
+    # Test whether or not a node can be recreated with the string from node_to_json_str
+    # node_to_json_str has a wrong config format, thus the name config string will create, as of now,
+    # a node without a name
+    # uuid can not match
+    def test_config_from_string(self):
+        try:
+            config_str = vn.node_to_json_str(self.test_node)
+            config_obj = json.loads(config_str)
+
+            config_copy_str = json.dumps(config_obj, indent=2)
+
+            test_node = vn.node_new("", config_copy_str)
+
+            self.assertEqual(
+                re.sub(r'^[^:]+: uuid=[0-9a-fA-F-]+, ', '', vn.node_name_full(test_node)),
+                re.sub(r'^[^:]+: uuid=[0-9a-fA-F-]+, ', '', vn.node_name_full(self.test_node))
+            )
+        except Exception as e:
+            self.fail(f" err: {e}")
+
+    def test_rw_socket(self):
+        try:
+            data_str = json.dumps(send_recv_test, indent=2)
+            data = json.loads(data_str)
+
+            test_nodes = {}
+            for name, content in data.items():
+                obj = {name: content}
+                config = json.dumps(obj, indent=2)
+                id = str(uuid.uuid4())
+
+                test_nodes[name] = vn.node_new(id, config)
+
+            for node in test_nodes.values():
+                if vn.node_check(node):
+                    raise RuntimeError(f"Failed to verify node configuration")
+                if vn.node_prepare(node):
+                    raise RuntimeError(f"Failed to verify {vn.node_name(node)} node configuration")
+                vn.node_start(node)
+
+            # Arrays to store samples
+            send_smpls = vn.smps_array(1)
+            intmdt_smpls = vn.smps_array(100)
+            recv_smpls = vn.smps_array(100)
+
+            for i in range(100):
+                send_smpls[0] = vn.sample_alloc(2)
+                intmdt_smpls[i] = vn.sample_alloc(2)
+                recv_smpls[i] = vn.sample_alloc(2)
+
+                # Generate signals and send over send_socket
+                self.assertEqual(vn.node_read(test_nodes["signal_generator"], send_smpls, 1), 1)
+                self.assertEqual(vn.node_write(test_nodes["send_socket"], send_smpls, 1), 1)
+
+            # read received signals and send them to recv_socket
+            self.assertEqual(vn.node_read(test_nodes["intmdt_socket"], intmdt_smpls, 100), 100)
+            self.assertEqual(vn.node_write(test_nodes["intmdt_socket"], intmdt_smpls, 100), 100)
+
+            # confirm rev_socket signals
+            self.assertEqual(vn.node_read(test_nodes["recv_socket"], recv_smpls, 100), 100)
+
+        except Exception as e:
+            self.fail(f" err: {e}")
+
+
+test_node_config = {
+    "test_node": {
+        "type": "socket",
+        "format": "villas.binary",
+        "layer": "udp",
+        "in": {
+            "address": "*:12000",
+            "signals": [{
+                "name": "tap_position",
+                "type": "integer",
+                "init": 0
+            }]
+        },
+        "out": {
+            "address": "127.0.0.1:12001"
+        }
+    }
+}
+
+send_recv_test = {
+    "send_socket": {
+        "type": "socket",
+        "format": "protobuf",
+        "layer": "udp",
+        "in": {
+            "address": "127.0.0.1:65532",
+            "signals": [
+                {
+                    "name": "voltage",
+                    "type": "float",
+                    "unit": "V"
+                },
+                {
+                    "name": "current",
+                    "type": "float",
+                    "unit": "A"
+                }
+            ]
+        },
+        "out": {
+            "address": "127.0.0.1:65533",
+            "netem": {
+                "enabled": False
+            },
+            "multicast": {
+                "enabled": False
+            }
+        }
+    },
+    "intmdt_socket": {
+        "type": "socket",
+        "format": "protobuf",
+        "layer": "udp",
+        "in": {
+            "address": "127.0.0.1:65533",
+            "signals": [
+                {
+                    "name": "voltage",
+                    "type": "float",
+                    "unit": "V"
+                },
+                {
+                    "name": "current",
+                    "type": "float",
+                    "unit": "A"
+                }
+            ]
+        },
+        "out": {
+            "address": "127.0.0.1:65534",
+            "netem": {
+                "enabled": False
+            },
+            "multicast": {
+                "enabled": False
+            }
+        }
+    },
+    "recv_socket": {
+        "type": "socket",
+        "format": "protobuf",
+        "layer": "udp",
+        "in": {
+            "address": "127.0.0.1:65534",
+            "signals": [
+                {
+                    "name": "voltage",
+                    "type": "float",
+                    "unit": "V"
+                },
+                {
+                    "name": "current",
+                    "type": "float",
+                    "unit": "A"
+                }
+            ]
+        },
+        "out": {
+            "address": "127.0.0.1:65535",
+            "netem": {
+                "enabled": False
+            },
+            "multicast": {
+                "enabled": False
+            }
+        }
+    },
+    "signal_generator": {
+        "type": "signal.v2",
+        "limit": 100,
+        "rate": 10,
+        "in": {
+            "signals": [
+                {
+                    "amplitude": 2,
+                    "name": "voltage",
+                    "phase": 90,
+                    "signal": "sine",
+                    "type": "float",
+                    "unit": "V"
+                },
+                {
+                    "amplitude": 1,
+                    "name": "current",
+                    "phase": 0,
+                    "signal": "sine",
+                    "type": "float",
+                    "unit": "A"
+                }
+            ],
+            "hooks": [
+                {
+                    "type": "print",
+                    "format": "villas.human"
+                }
+            ]
+        }
+    }
+}
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Left to do:

Add docstrings to the python-wrapper bindings once documentation is finalized.
 
### Side notes:

As noted in a64e0dc, potential CI issue with running the python-wrapper tests (permissions).

sample_pack() and sample_unpack() may need additional work, not yet tested.

### Following could be investigated:

node_name_short() bug - appears to be returning a free'd string.

node_stop() and node_restart() do not work as expected with the signal_v2 node in the dev container.
Behavior between some functions differs from my live system to the dev container.

As an example:
node_check() and node_prepare() do not need to be called before starting the signal_v2 node (works just fine on live system).
node_stop() and node_restart() work just fine as well.

That however is not the case in the dev container.