### PR TITLE
Python-Wrapper fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,7 +170,7 @@ test:unit:
   script:
     - cmake -S . -B build ${CMAKE_OPTS}
     - cmake --build build ${CMAKE_BUILD_OPTS} --target run-unit-tests run-unit-tests-common
-    - cmake --build build ${CMAKE_BUILD_OPTS} --target python-wrapper-tests
+    - cmake --build build ${CMAKE_BUILD_OPTS} --target run-python-wrapper-tests
   needs:
     - job: "build:source: [fedora]"
       artifacts: true

--- a/clients/python-wrapper/CMakeLists.txt
+++ b/clients/python-wrapper/CMakeLists.txt
@@ -11,7 +11,7 @@ set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG)
 
 if(pybind11_FOUND)
-  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
   execute_process(
     COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_path('stdlib') + '/lib-dynload')"

--- a/clients/python-wrapper/villas-python-wrapper.cpp
+++ b/clients/python-wrapper/villas-python-wrapper.cpp
@@ -23,6 +23,9 @@ class Array {
       smps = new vsample *[len]();
       this->len = len;
     }
+    Array(const Array&) = delete;
+    Array& operator= (const Array&) = delete;
+
     ~Array() {
       for(unsigned int i = 0; i < len; ++i) {
         sample_decref(smps[i]);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -35,6 +35,7 @@ add_custom_target(run-unit-tests
     USES_TERMINAL
 )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 add_custom_target(run-python-wrapper-tests
     COMMAND
         ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tests/unit/python_wrapper.py


### PR DESCRIPTION
Pipeline failed, because cppcheck complained about assignment operator and copy-constructor in
the Array class for holding samples. They weren't used anyways so this should fix the warning and not cause any problems.

Small changes to CMakelists.txt to align with CMake guidelines and so that the python executable is found for running
the python-wrapper unit tests.

Fixed typo in ci.yml now calling the right target