### PR TITLE
Fixes to compile in Fedora 42

### DIFF
--- a/fpga/include/villas/fpga/ips/gpu2rtds.hpp
+++ b/fpga/include/villas/fpga/ips/gpu2rtds.hpp
@@ -25,6 +25,9 @@ public:
   virtual bool init() override;
 
   void dump(spdlog::level::level_enum logLevel = spdlog::level::info);
+
+  void dump() override { dump(spdlog::level::info); }
+
   bool startOnce(size_t frameSize);
 
   size_t getMaxFrameSize();

--- a/fpga/include/villas/fpga/ips/rtds2gpu/register_types.hpp
+++ b/fpga/include/villas/fpga/ips/rtds2gpu/register_types.hpp
@@ -43,11 +43,12 @@ template <size_t N, typename T = uint32_t> struct Rtds2GpuMemoryBuffer {
   //static constexpr size_t doorbellOffset = offsetof(Rtds2GpuMemoryBuffer, doorbell);
   //static constexpr size_t dataOffset = offsetof(Rtds2GpuMemoryBuffer, data);
 
+  T data[N];
+
   // HACK: This might break horribly, let's just hope C++17 will be there soon
   static constexpr size_t dataOffset = 0;
   static constexpr size_t doorbellOffset =
       N * sizeof(Rtds2GpuMemoryBuffer::data);
 
-  T data[N];
   reg_doorbell_t doorbell;
 };


### PR DESCRIPTION
This introduces changes to comply with some stricter rules on the compiler.
- The template definiton was moved before the hack in the register_types
- Override instead of hide for the dump() function