### PR TITLE
Add support for newer cmake versions (and their policies)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,25 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-project(villas-node
-    VERSION 0.0.0
-    DESCRIPTION "VILLASnode"
-    HOMEPAGE_URL "https://www.fein-aachen.org/projects/villas-node/"
-    LANGUAGES C CXX
-)
+include(CheckLanguage)
+# Check if CUDA is available
+check_language(CUDA)
+
+if(CMAKE_CUDA_COMPILER)
+    project(villas-node
+        VERSION 0.0.0
+        DESCRIPTION "VILLASnode"
+        HOMEPAGE_URL "https://www.fein-aachen.org/projects/villas-node/"
+        LANGUAGES C CXX CUDA
+    )
+else()
+    project(villas-node
+        VERSION 0.0.0
+        DESCRIPTION "VILLASnode"
+        HOMEPAGE_URL "https://www.fein-aachen.org/projects/villas-node/"
+        LANGUAGES C CXX
+    )
+endif()
 
 # Some more project settings
 set(PROJECT_AUTHOR "Steffen Vogel")

--- a/fpga/gpu/CMakeLists.txt
+++ b/fpga/gpu/CMakeLists.txt
@@ -20,7 +20,7 @@ set_source_files_properties(src/gpu.cpp PROPERTIES
 
 target_include_directories(villas-gpu
     PRIVATE
-        /opt/cuda/include
+    ${CUDA_INCLUDE_DIRS}
 )
 
 target_link_libraries(villas-gpu


### PR DESCRIPTION
This PR adds:
- A check for CUDA language availability in CMakeLists of the main villlas-node
- Changes the hardcoding of a path in for villas-fpga (in gpu)

This gives some errors related to CMP0146 and CMP0104 in newer CMake versions

This is needed in sogno-platform/dpsim#334 (was tested locally)