### PR TITLE
Enforce project wide `#include` order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,18 @@ BasedOnStyle: LLVM
 # Disable automatic line-breaks in comments
 # as this breaks SPDX headers
 ReflowComments: false
+
+# Regroup #include directives to villas - std - other
+IncludeBlocks: Regroup
+IncludeIsMainRegex: / # disable main header heuristic
+IncludeCategories:
+  - Regex: '^<villas/'
+    Priority: 3
+    CaseSensitive: true
+  - Regex: '^<[[:lower:]_]+>$'
+    Priority: 1
+    CaseSensitive: true
+  - Regex: '^<.*>$'
+    Priority: 2
+  - Regex: '^".*"$'
+    Priority: 4

--- a/clients/opal-rt/rtlab-asyncip/models/send_receive/src/socket.c
+++ b/clients/opal-rt/rtlab-asyncip/models/send_receive/src/socket.c
@@ -19,7 +19,6 @@
 #define RTLAB
 #include "AsyncApi.h"
 #include "OpalPrint.h"
-
 #include "config.h"
 #include "socket.h"
 

--- a/clients/opal-rt/rtlab-asyncip/models/send_receive/src/utils.c
+++ b/clients/opal-rt/rtlab-asyncip/models/send_receive/src/utils.c
@@ -14,7 +14,6 @@
  * to the OpalDisplay. Otherwise stdout will be used. */
 #define RTLAB
 #include "OpalPrint.h"
-
 #include "config.h"
 #include "utils.h"
 

--- a/common/include/villas/buffer.hpp
+++ b/common/include/villas/buffer.hpp
@@ -7,9 +7,8 @@
 
 #pragma once
 
-#include <vector>
-
 #include <cstdlib>
+#include <vector>
 
 #include <jansson.h>
 

--- a/common/include/villas/cpuset.hpp
+++ b/common/include/villas/cpuset.hpp
@@ -10,6 +10,7 @@
 #ifdef __linux__
 
 #include <cstdint>
+
 #include <sched.h>
 
 #include <villas/exceptions.hpp>

--- a/common/include/villas/dsp/moving_average_window.hpp
+++ b/common/include/villas/dsp/moving_average_window.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+
 #include <villas/dsp/window.hpp>
 
 namespace villas {

--- a/common/include/villas/dsp/window_cosine.hpp
+++ b/common/include/villas/dsp/window_cosine.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <cmath>
-
 #include <vector>
 
 #include <villas/dsp/window.hpp>

--- a/common/include/villas/graph/edge.hpp
+++ b/common/include/villas/graph/edge.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fmt/ostream.h>
+
 #include <villas/config.hpp>
 #include <villas/graph/vertex.hpp>
 

--- a/common/include/villas/graph/vertex.hpp
+++ b/common/include/villas/graph/vertex.hpp
@@ -7,9 +7,11 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
 #include <list>
 #include <sstream>
+
+#include <fmt/ostream.h>
+
 #include <villas/config.hpp>
 
 namespace villas {

--- a/common/include/villas/kernel/devices/device.hpp
+++ b/common/include/villas/kernel/devices/device.hpp
@@ -10,6 +10,7 @@
 
 #include <filesystem>
 #include <optional>
+
 #include <villas/kernel/devices/driver.hpp>
 
 namespace villas {

--- a/common/include/villas/kernel/devices/driver.hpp
+++ b/common/include/villas/kernel/devices/driver.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace villas {
 namespace kernel {
 namespace devices {

--- a/common/include/villas/kernel/devices/ip_device.hpp
+++ b/common/include/villas/kernel/devices/ip_device.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <filesystem>
+#include <vector>
+
 #include <villas/kernel/devices/platform_device.hpp>
 
 namespace villas {

--- a/common/include/villas/kernel/devices/linux_driver.hpp
+++ b/common/include/villas/kernel/devices/linux_driver.hpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+
 #include <villas/kernel/devices/driver.hpp>
 
 namespace villas {

--- a/common/include/villas/kernel/devices/pci_device.hpp
+++ b/common/include/villas/kernel/devices/pci_device.hpp
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include <fstream>
-#include <list>
-
 #include <cstddef>
 #include <cstdint>
+#include <fstream>
+#include <list>
 
 #include <villas/log.hpp>
 

--- a/common/include/villas/kernel/devices/platform_device.hpp
+++ b/common/include/villas/kernel/devices/platform_device.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <filesystem>
+
 #include <villas/kernel/devices/device.hpp>
 #include <villas/kernel/devices/driver.hpp>
 

--- a/common/include/villas/list.hpp
+++ b/common/include/villas/list.hpp
@@ -14,8 +14,9 @@
 #pragma once
 
 #include <cstring>
-#include <pthread.h>
 #include <string>
+
+#include <pthread.h>
 #include <sys/types.h>
 
 #include <villas/common.hpp>

--- a/common/include/villas/log.hpp
+++ b/common/include/villas/log.hpp
@@ -11,11 +11,10 @@
 #include <list>
 #include <string>
 
+#include <jansson.h>
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
-
-#include <jansson.h>
 
 namespace villas {
 

--- a/common/include/villas/memory.hpp
+++ b/common/include/villas/memory.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <string>
+
 #include <unistd.h>
 
 #include <villas/log.hpp>

--- a/common/include/villas/memory_manager.hpp
+++ b/common/include/villas/memory_manager.hpp
@@ -8,11 +8,13 @@
 #pragma once
 
 #include <cstdint>
-#include <fmt/ostream.h>
 #include <map>
 #include <stdexcept>
 #include <string>
+
+#include <fmt/ostream.h>
 #include <unistd.h>
+
 #include <villas/config.hpp>
 #include <villas/graph/directed.hpp>
 #include <villas/log.hpp>

--- a/common/include/villas/plugin.hpp
+++ b/common/include/villas/plugin.hpp
@@ -8,11 +8,13 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
 #include <iostream>
-#include <jansson.h>
 #include <list>
 #include <string>
+
+#include <fmt/ostream.h>
+#include <jansson.h>
+
 #include <villas/common.hpp>
 #include <villas/config.hpp>
 #include <villas/log.hpp>

--- a/common/include/villas/popen.hpp
+++ b/common/include/villas/popen.hpp
@@ -7,16 +7,15 @@
 
 #pragma once
 
-#include <signal.h>
-
-#include <ext/stdio_filebuf.h>
-
 #include <istream>
 #include <map>
 #include <memory>
 #include <ostream>
 #include <string>
 #include <vector>
+
+#include <ext/stdio_filebuf.h>
+#include <signal.h>
 
 namespace villas {
 namespace utils {

--- a/common/include/villas/task.hpp
+++ b/common/include/villas/task.hpp
@@ -9,7 +9,6 @@
 
 #include <cstdint>
 #include <cstdio>
-
 #include <ctime>
 
 namespace villas {

--- a/common/include/villas/timing.hpp
+++ b/common/include/villas/timing.hpp
@@ -9,7 +9,6 @@
 
 #include <cstdint>
 #include <cstdio>
-
 #include <ctime>
 
 // Compare two timestamps. Return zero if they are equal.

--- a/common/include/villas/utils.hpp
+++ b/common/include/villas/utils.hpp
@@ -8,19 +8,18 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <list>
 #include <string>
 #include <vector>
 
-#include <cassert>
-#include <cstdint>
-#include <cstdlib>
+#include <openssl/sha.h>
 #include <sched.h>
 #include <signal.h>
 #include <sys/types.h>
-
-#include <openssl/sha.h>
 
 #include <villas/config.hpp>
 

--- a/common/lib/common.cpp
+++ b/common/lib/common.cpp
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/common.hpp>
-
 #include <cstdlib>
+
+#include <villas/common.hpp>
 
 std::string stateToString(enum State s) {
   switch (s) {

--- a/common/lib/compat.cpp
+++ b/common/lib/compat.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <jansson.h>
 #include <unistd.h>
 

--- a/common/lib/dsp/pid.cpp
+++ b/common/lib/dsp/pid.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <iostream>
+
 #include <villas/dsp/pid.hpp>
 
 using namespace std;

--- a/common/lib/kernel/devices/device_connection.cpp
+++ b/common/lib/kernel/devices/device_connection.cpp
@@ -6,10 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/kernel/devices/device_connection.hpp>
-
 #include <memory>
 
+#include <villas/kernel/devices/device_connection.hpp>
 #include <villas/kernel/devices/linux_driver.hpp>
 #include <villas/memory_manager.hpp>
 

--- a/common/lib/kernel/devices/linux_driver.cpp
+++ b/common/lib/kernel/devices/linux_driver.cpp
@@ -6,9 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/kernel/devices/linux_driver.hpp>
-
 #include <villas/kernel/devices/device.hpp>
+#include <villas/kernel/devices/linux_driver.hpp>
 #include <villas/utils.hpp>
 
 using villas::kernel::devices::Device, villas::kernel::devices::LinuxDriver;

--- a/common/lib/kernel/devices/pci_device.cpp
+++ b/common/lib/kernel/devices/pci_device.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <cstring>
+
 #include <dirent.h>
 #include <fcntl.h>
 #include <libgen.h>

--- a/common/lib/kernel/kernel.cpp
+++ b/common/lib/kernel/kernel.cpp
@@ -9,20 +9,18 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+
 #include <fcntl.h>
+#include <sys/types.h>
 #include <sys/utsname.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
-#include <sys/types.h>
-#include <sys/wait.h>
-
 #include <villas/config.hpp>
+#include <villas/exceptions.hpp>
 #include <villas/kernel/kernel.hpp>
 #include <villas/log.hpp>
 #include <villas/utils.hpp>
-
-#include <villas/exceptions.hpp>
-#include <villas/kernel/kernel.hpp>
 
 using namespace villas;
 using namespace villas::utils;

--- a/common/lib/kernel/rt.cpp
+++ b/common/lib/kernel/rt.cpp
@@ -11,11 +11,10 @@
 #include <villas/config.hpp>
 #include <villas/cpuset.hpp>
 #include <villas/exceptions.hpp>
-#include <villas/log.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/kernel/kernel.hpp>
 #include <villas/kernel/rt.hpp>
+#include <villas/log.hpp>
+#include <villas/utils.hpp>
 
 #ifdef __linux__
 using villas::utils::CpuSet;

--- a/common/lib/kernel/vfio_container.cpp
+++ b/common/lib/kernel/vfio_container.cpp
@@ -18,14 +18,13 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <sstream>
 #include <string>
 
-#include <cstdlib>
-#include <cstring>
-
-#include <cstdint>
 #include <fcntl.h>
 #include <linux/pci_regs.h>
 #include <sys/eventfd.h>

--- a/common/lib/kernel/vfio_group.cpp
+++ b/common/lib/kernel/vfio_group.cpp
@@ -17,14 +17,13 @@
 #endif
 
 #include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <sstream>
 #include <string>
 
-#include <cstdlib>
-#include <cstring>
-
-#include <cstdint>
 #include <fcntl.h>
 #include <linux/pci_regs.h>
 #include <sys/eventfd.h>

--- a/common/lib/list.cpp
+++ b/common/lib/list.cpp
@@ -9,7 +9,6 @@
 
 #include <algorithm>
 #include <array>
-
 #include <cstdlib>
 #include <cstring>
 

--- a/common/lib/log.cpp
+++ b/common/lib/log.cpp
@@ -10,7 +10,6 @@
 #include <map>
 
 #include <fnmatch.h>
-
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/syslog_sink.h>
 

--- a/common/lib/memory.cpp
+++ b/common/lib/memory.cpp
@@ -5,13 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/mman.h>
-
-#include <fcntl.h>
-#include <unistd.h>
-
 #include <fstream>
 #include <sstream>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include <villas/memory.hpp>
 

--- a/common/lib/plugin.cpp
+++ b/common/lib/plugin.cpp
@@ -5,11 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dlfcn.h>
 #include <iostream>
 #include <new>
 #include <string>
 #include <type_traits>
+
+#include <dlfcn.h>
 
 #include <villas/plugin.hpp>
 

--- a/common/lib/popen.cpp
+++ b/common/lib/popen.cpp
@@ -5,8 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
 #include <dirent.h>
 #include <fcntl.h>
+#include <fmt/core.h>
 #include <paths.h>
 #include <signal.h>
 #include <sys/stat.h>
@@ -14,14 +21,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <cerrno>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-
-#include <iostream>
-
-#include <fmt/core.h>
 #include <villas/exceptions.hpp>
 #include <villas/popen.hpp>
 #include <villas/utils.hpp>

--- a/common/lib/task.cpp
+++ b/common/lib/task.cpp
@@ -7,6 +7,7 @@
 
 #include <cerrno>
 #include <ctime>
+
 #include <unistd.h>
 
 #include <villas/exceptions.hpp>

--- a/common/lib/utils.cpp
+++ b/common/lib/utils.cpp
@@ -6,10 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <iostream>
-#include <string>
-#include <vector>
-
 #include <cctype>
 #include <cmath>
 #include <cstdarg>
@@ -17,18 +13,20 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <dirent.h>
-#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <pthread.h>
-#include <unistd.h>
+#include <string>
+#include <vector>
 
+#include <dirent.h>
+#include <fcntl.h>
 #include <jansson.h>
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
+#include <pthread.h>
+#include <unistd.h>
 
 #include <villas/colors.hpp>
 #include <villas/config.hpp>

--- a/common/tests/unit/base64.cpp
+++ b/common/tests/unit/base64.cpp
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <criterion/criterion.h>
-
 #include <iostream>
+
+#include <criterion/criterion.h>
 
 #include <villas/utils.hpp>
 

--- a/common/tests/unit/graph.cpp
+++ b/common/tests/unit/graph.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include <criterion/criterion.h>
+
 #include <villas/graph/directed.hpp>
 #include <villas/log.hpp>
 #include <villas/memory_manager.hpp>

--- a/common/tests/unit/kernel.cpp
+++ b/common/tests/unit/kernel.cpp
@@ -5,9 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <unistd.h>
-
 #include <criterion/criterion.h>
+#include <unistd.h>
 
 #include <villas/kernel/kernel.hpp>
 #include <villas/utils.hpp>

--- a/common/tests/unit/list.cpp
+++ b/common/tests/unit/list.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <criterion/criterion.h>
 #include <cstdint>
 #include <cstring>
+
+#include <criterion/criterion.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/list.hpp>

--- a/common/tests/unit/popen.cpp
+++ b/common/tests/unit/popen.cpp
@@ -5,8 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <criterion/criterion.h>
 #include <iostream>
+
+#include <criterion/criterion.h>
 
 #include <villas/popen.hpp>
 

--- a/common/tests/unit/task.cpp
+++ b/common/tests/unit/task.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <criterion/criterion.h>
-
 #include <math.h>
 
 #include <villas/task.hpp>

--- a/fpga/include/villas/fpga/card_parser.hpp
+++ b/fpga/include/villas/fpga/card_parser.hpp
@@ -13,6 +13,7 @@
 
 #include <jansson.h>
 #include <spdlog/logger.h>
+
 #include <villas/exceptions.hpp>
 #include <villas/log.hpp>
 

--- a/fpga/include/villas/fpga/core.hpp
+++ b/fpga/include/villas/fpga/core.hpp
@@ -10,11 +10,13 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
-#include <jansson.h>
 #include <list>
 #include <map>
 #include <memory>
+
+#include <fmt/ostream.h>
+#include <jansson.h>
+
 #include <villas/colors.hpp>
 #include <villas/config.hpp>
 #include <villas/fpga/vlnv.hpp>

--- a/fpga/include/villas/fpga/ips/dma.hpp
+++ b/fpga/include/villas/fpga/ips/dma.hpp
@@ -10,13 +10,12 @@
 #pragma once
 
 #include <fmt/ostream.h>
+#include <xilinx/xaxidma.h>
 
 #include <villas/config.hpp>
 #include <villas/exceptions.hpp>
 #include <villas/fpga/node.hpp>
 #include <villas/memory.hpp>
-
-#include <xilinx/xaxidma.h>
 
 namespace villas {
 namespace fpga {

--- a/fpga/include/villas/fpga/ips/gpu2rtds.hpp
+++ b/fpga/include/villas/fpga/ips/gpu2rtds.hpp
@@ -8,11 +8,10 @@
 #pragma once
 
 #include <villas/fpga/ips/hls.hpp>
-#include <villas/fpga/node.hpp>
-#include <villas/memory.hpp>
-
 #include <villas/fpga/ips/rtds2gpu/register_types.hpp>
 #include <villas/fpga/ips/rtds2gpu/xgpu2rtds_hw.h>
+#include <villas/fpga/node.hpp>
+#include <villas/memory.hpp>
 
 namespace villas {
 namespace fpga {

--- a/fpga/include/villas/fpga/ips/i2c.hpp
+++ b/fpga/include/villas/fpga/ips/i2c.hpp
@@ -8,11 +8,12 @@
 #pragma once
 
 #include <fmt/ostream.h>
+#include <xilinx/xiic.h>
+
 #include <villas/config.hpp>
 #include <villas/exceptions.hpp>
 #include <villas/fpga/node.hpp>
 #include <villas/memory.hpp>
-#include <xilinx/xiic.h>
 
 namespace villas {
 namespace fpga {

--- a/fpga/include/villas/fpga/ips/rtds2gpu/register_types.hpp
+++ b/fpga/include/villas/fpga/ips/rtds2gpu/register_types.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+
 #include <stdint.h>
 
 union axilite_reg_status_t {

--- a/fpga/include/villas/fpga/ips/timer.hpp
+++ b/fpga/include/villas/fpga/ips/timer.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include <xilinx/xtmrctr.h>
 
 #include <villas/fpga/config.h>

--- a/fpga/include/villas/fpga/json_parser.hpp
+++ b/fpga/include/villas/fpga/json_parser.hpp
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include <jansson.h>
 #include <memory>
-#include <spdlog/common.h>
 #include <string>
+
+#include <jansson.h>
+#include <spdlog/common.h>
 
 class JsonParser {
 private:

--- a/fpga/include/villas/fpga/node.hpp
+++ b/fpga/include/villas/fpga/node.hpp
@@ -10,10 +10,12 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
-#include <jansson.h>
 #include <map>
 #include <string>
+
+#include <fmt/ostream.h>
+#include <jansson.h>
+
 #include <villas/config.hpp>
 #include <villas/fpga/core.hpp>
 #include <villas/graph/directed.hpp>

--- a/fpga/include/villas/fpga/pcie_card.hpp
+++ b/fpga/include/villas/fpga/pcie_card.hpp
@@ -11,20 +11,19 @@
 #pragma once
 
 #include <filesystem>
-#include <jansson.h>
 #include <list>
 #include <set>
 #include <string>
 
-#include <villas/memory.hpp>
-#include <villas/plugin.hpp>
-
-#include <villas/kernel/devices/pci_device.hpp>
-#include <villas/kernel/vfio_container.hpp>
+#include <jansson.h>
 
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/config.h>
 #include <villas/fpga/core.hpp>
+#include <villas/kernel/devices/pci_device.hpp>
+#include <villas/kernel/vfio_container.hpp>
+#include <villas/memory.hpp>
+#include <villas/plugin.hpp>
 
 namespace villas {
 namespace fpga {

--- a/fpga/include/villas/fpga/utils.hpp
+++ b/fpga/include/villas/fpga/utils.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+
 #include <villas/fpga/ips/aurora_xilinx.hpp>
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/pcie_card.hpp>

--- a/fpga/include/villas/fpga/vlnv.hpp
+++ b/fpga/include/villas/fpga/vlnv.hpp
@@ -7,10 +7,12 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#include <fmt/ostream.h>
+
 #include <villas/config.hpp>
 
 namespace villas {

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -10,20 +10,18 @@
 #include <utility>
 
 #include <villas/exceptions.hpp>
-#include <villas/log.hpp>
-#include <villas/memory.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
-#include <villas/fpga/utils.hpp>
-#include <villas/fpga/vlnv.hpp>
-
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/ips/intc.hpp>
 #include <villas/fpga/ips/pcie.hpp>
 #include <villas/fpga/ips/platform_intc.hpp>
 #include <villas/fpga/ips/switch.hpp>
 #include <villas/fpga/platform_card.hpp>
+#include <villas/fpga/utils.hpp>
+#include <villas/fpga/vlnv.hpp>
+#include <villas/log.hpp>
+#include <villas/memory.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas::fpga;
 using namespace villas::fpga::ip;

--- a/fpga/lib/dma.cpp
+++ b/fpga/lib/dma.cpp
@@ -5,19 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/fpga/dma.h>
-
 #include <string>
 
 #include <villas/exceptions.hpp>
-#include <villas/log.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/core.hpp>
+#include <villas/fpga/dma.h>
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/utils.hpp>
 #include <villas/fpga/vlnv.hpp>
+#include <villas/log.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas;
 

--- a/fpga/lib/ips/aurora.cpp
+++ b/fpga/lib/ips/aurora.cpp
@@ -7,9 +7,8 @@
 
 #include <cstdint>
 
-#include <villas/utils.hpp>
-
 #include <villas/fpga/ips/aurora.hpp>
+#include <villas/utils.hpp>
 
 // Register offsets
 #define AURORA_AXIS_SR_OFFSET 0x00 // Status Register (read-only)

--- a/fpga/lib/ips/aurora_xilinx.cpp
+++ b/fpga/lib/ips/aurora_xilinx.cpp
@@ -7,9 +7,8 @@
 
 #include <cstdint>
 
-#include <villas/utils.hpp>
-
 #include <villas/fpga/ips/aurora_xilinx.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas::fpga::ip;
 

--- a/fpga/lib/ips/dino.cpp
+++ b/fpga/lib/ips/dino.cpp
@@ -7,10 +7,9 @@
 
 #include <cstdint>
 
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/dino.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas::fpga::ip;
 

--- a/fpga/lib/ips/dma.cpp
+++ b/fpga/lib/ips/dma.cpp
@@ -8,16 +8,16 @@
 
 #include <sstream>
 #include <string>
+
 #include <sys/types.h>
+#include <xilinx/xaxidma.h>
+#include <xilinx/xaxidma_bd.h>
+#include <xilinx/xaxidma_hw.h>
 
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/ips/intc.hpp>
 #include <villas/memory.hpp>
-
-#include <xilinx/xaxidma.h>
-#include <xilinx/xaxidma_bd.h>
-#include <xilinx/xaxidma_hw.h>
 
 // Max. size of a DMA transfer in simple mode
 #define FPGA_DMA_BOUNDARY 0x1000

--- a/fpga/lib/ips/fifo.cpp
+++ b/fpga/lib/ips/fifo.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <unistd.h>
-
 #include <xilinx/xllfifo.h>
 #include <xilinx/xstatus.h>
 

--- a/fpga/lib/ips/gpio.cpp
+++ b/fpga/lib/ips/gpio.cpp
@@ -5,9 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/plugin.hpp>
-
 #include <villas/fpga/ips/gpio.hpp>
+#include <villas/plugin.hpp>
 
 using namespace villas::fpga::ip;
 

--- a/fpga/lib/ips/intc.cpp
+++ b/fpga/lib/ips/intc.cpp
@@ -10,13 +10,11 @@
 #include <unistd.h>
 
 #include <villas/config.hpp>
-#include <villas/plugin.hpp>
-
-#include <villas/kernel/kernel.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/intc.hpp>
 #include <villas/fpga/pcie_card.hpp>
+#include <villas/kernel/kernel.hpp>
+#include <villas/plugin.hpp>
 
 using namespace villas::fpga::ip;
 

--- a/fpga/lib/ips/pcie.cpp
+++ b/fpga/lib/ips/pcie.cpp
@@ -5,15 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <jansson.h>
 #include <limits>
 
-#include <villas/exceptions.hpp>
-#include <villas/memory.hpp>
+#include <jansson.h>
 
+#include <villas/exceptions.hpp>
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/pcie.hpp>
 #include <villas/fpga/pcie_card.hpp>
+#include <villas/memory.hpp>
 
 using namespace villas::fpga::ip;
 

--- a/fpga/lib/ips/rtds.cpp
+++ b/fpga/lib/ips/rtds.cpp
@@ -7,9 +7,8 @@
 
 #include <cstdint>
 
-#include <villas/utils.hpp>
-
 #include <villas/fpga/ips/rtds.hpp>
+#include <villas/utils.hpp>
 
 #define RTDS_HZ 100000000 // 100 MHz
 

--- a/fpga/lib/ips/rtds2gpu/gpu2rtds.cpp
+++ b/fpga/lib/ips/rtds2gpu/gpu2rtds.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <unistd.h>
 
 #include <villas/fpga/ips/gpu2rtds.hpp>

--- a/fpga/lib/ips/rtds2gpu/rtds2gpu.cpp
+++ b/fpga/lib/ips/rtds2gpu/rtds2gpu.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <unistd.h>
 
 #include <villas/fpga/ips/rtds2gpu.hpp>

--- a/fpga/lib/ips/zynq.cpp
+++ b/fpga/lib/ips/zynq.cpp
@@ -5,9 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/fpga/ips/zynq.hpp>
-
 #include <villas/fpga/card.hpp>
+#include <villas/fpga/ips/zynq.hpp>
 #include <villas/memory.hpp>
 
 using namespace villas::fpga::ip;

--- a/fpga/lib/node.cpp
+++ b/fpga/lib/node.cpp
@@ -5,16 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <jansson.h>
 #include <map>
 #include <stdexcept>
 
-#include <villas/exceptions.hpp>
-#include <villas/utils.hpp>
+#include <jansson.h>
 
+#include <villas/exceptions.hpp>
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/switch.hpp>
 #include <villas/fpga/node.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas::fpga::ip;
 

--- a/fpga/lib/pcie_card.cpp
+++ b/fpga/lib/pcie_card.cpp
@@ -5,10 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <fmt/ostream.h>
 #include <memory>
 #include <string>
 #include <utility>
+
+#include <fmt/ostream.h>
+
 #include <villas/exceptions.hpp>
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/pcie_card.hpp>

--- a/fpga/lib/platform_card.cpp
+++ b/fpga/lib/platform_card.cpp
@@ -10,8 +10,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <jansson.h>
 #include <string>
+
+#include <jansson.h>
 
 #include <villas/fpga/card_parser.hpp>
 #include <villas/fpga/platform_card.hpp>

--- a/fpga/lib/utils.cpp
+++ b/fpga/lib/utils.cpp
@@ -9,17 +9,14 @@
 #include <csignal>
 #include <filesystem>
 #include <iostream>
-#include <jansson.h>
 #include <regex>
 #include <string>
 #include <vector>
 
+#include <jansson.h>
 #include <rang.hpp>
 
 #include <villas/exceptions.hpp>
-#include <villas/log.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/ips/aurora_xilinx.hpp>
@@ -29,6 +26,8 @@
 #include <villas/fpga/platform_card.hpp>
 #include <villas/fpga/utils.hpp>
 #include <villas/fpga/vlnv.hpp>
+#include <villas/log.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas;
 

--- a/fpga/src/villas-fpga-ctrl.cpp
+++ b/fpga/src/villas-fpga-ctrl.cpp
@@ -9,18 +9,15 @@
 
 #include <algorithm>
 #include <iostream>
-#include <jansson.h>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include <CLI11.hpp>
+#include <jansson.h>
 #include <rang.hpp>
 
 #include <villas/exceptions.hpp>
-#include <villas/log.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/ips/aurora_xilinx.hpp>
@@ -31,6 +28,8 @@
 #include <villas/fpga/ips/switch.hpp>
 #include <villas/fpga/utils.hpp>
 #include <villas/fpga/vlnv.hpp>
+#include <villas/log.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas;
 

--- a/fpga/src/villas-fpga-pipe.cpp
+++ b/fpga/src/villas-fpga-pipe.cpp
@@ -6,17 +6,14 @@
  */
 
 #include <iostream>
-#include <jansson.h>
 #include <string>
 #include <vector>
 
 #include <CLI11.hpp>
+#include <jansson.h>
 #include <rang.hpp>
 
 #include <villas/exceptions.hpp>
-#include <villas/log.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/ips/aurora_xilinx.hpp>
@@ -24,6 +21,8 @@
 #include <villas/fpga/ips/rtds.hpp>
 #include <villas/fpga/utils.hpp>
 #include <villas/fpga/vlnv.hpp>
+#include <villas/log.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas;
 

--- a/fpga/tests/unit/fifo.cpp
+++ b/fpga/tests/unit/fifo.cpp
@@ -7,11 +7,10 @@
 
 #include <criterion/criterion.h>
 
-#include <villas/log.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/fifo.hpp>
+#include <villas/log.hpp>
+#include <villas/utils.hpp>
 
 #include "global.hpp"
 

--- a/fpga/tests/unit/fpga.cpp
+++ b/fpga/tests/unit/fpga.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <criterion/criterion.h>
+#include <spdlog/spdlog.h>
 
 #include <villas/fpga/core.hpp>
 #include <villas/fpga/pcie_card.hpp>
@@ -15,8 +16,6 @@
 #include <villas/fpga/vlnv.hpp>
 
 #include "global.hpp"
-
-#include <spdlog/spdlog.h>
 
 #define FPGA_CARD "vc707"
 #define TEST_CONFIG "../etc/fpga.json"

--- a/fpga/tests/unit/logging.cpp
+++ b/fpga/tests/unit/logging.cpp
@@ -10,8 +10,8 @@
 
 #include <criterion/logging.h>
 #include <criterion/options.h>
-
 #include <spdlog/spdlog.h>
+
 #include <villas/log.hpp>
 
 extern "C" {

--- a/fpga/tests/unit/main.cpp
+++ b/fpga/tests/unit/main.cpp
@@ -9,10 +9,9 @@
 #include <criterion/hooks.h>
 #include <criterion/internal/ordered-set.h>
 #include <criterion/options.h>
+#include <spdlog/spdlog.h>
 
 #include <villas/log.hpp>
-
-#include <spdlog/spdlog.h>
 
 // Returns true if there is at least one enabled test in this suite
 static bool suite_enabled(struct criterion_test_set *tests, const char *name) {

--- a/fpga/tests/unit/rtds.cpp
+++ b/fpga/tests/unit/rtds.cpp
@@ -7,20 +7,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <chrono>
 #include <list>
 
 #include <criterion/criterion.h>
-
-#include <villas/log.hpp>
-#include <villas/memory.hpp>
-#include <villas/utils.hpp>
 
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/ips/rtds.hpp>
 #include <villas/fpga/ips/switch.hpp>
-
-#include <chrono>
+#include <villas/log.hpp>
+#include <villas/memory.hpp>
 #include <villas/utils.hpp>
 
 #include "global.hpp"

--- a/fpga/tests/unit/rtds2gpu.cpp
+++ b/fpga/tests/unit/rtds2gpu.cpp
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <criterion/criterion.h>
-
 #include <iostream>
 
-#include <villas/fpga/card.hpp>
-#include <villas/log.hpp>
-#include <villas/memory.hpp>
+#include <criterion/criterion.h>
 
+#include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/ips/gpu2rtds.hpp>
 #include <villas/fpga/ips/rtds.hpp>
 #include <villas/fpga/ips/rtds2gpu.hpp>
 #include <villas/fpga/ips/switch.hpp>
+#include <villas/log.hpp>
+#include <villas/memory.hpp>
 
 #include "global.hpp"
 

--- a/fpga/tests/unit/rtds_rtt.cpp
+++ b/fpga/tests/unit/rtds_rtt.cpp
@@ -8,11 +8,10 @@
 #include <criterion/criterion.h>
 
 #include <villas/fpga/card.hpp>
-#include <villas/fpga/vlnv.hpp>
-
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/ips/rtds.hpp>
 #include <villas/fpga/ips/switch.hpp>
+#include <villas/fpga/vlnv.hpp>
 
 extern struct fpga_card *card;
 

--- a/fpga/tests/unit/timer.cpp
+++ b/fpga/tests/unit/timer.cpp
@@ -6,13 +6,15 @@
  */
 
 #include <chrono>
+
 #include <criterion/criterion.h>
+
+#include <villas/config.hpp>
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/timer.hpp>
 #include <villas/log.hpp>
 
 #include "global.hpp"
-#include <villas/config.hpp>
 
 // cppcheck-suppress unknownMacro
 Test(fpga, timer, .description = "Timer Counter") {

--- a/fpga/thirdparty/rang/rang.hpp
+++ b/fpga/thirdparty/rang/rang.hpp
@@ -31,8 +31,9 @@
 #define _WIN32_WINNT _WIN32_WINNT_VISTA
 #endif
 
-#include <io.h>
 #include <memory>
+
+#include <io.h>
 #include <windows.h>
 
 // Only defined in windows 10 onwards, redefining in lower windows since it

--- a/include/villas/api.hpp
+++ b/include/villas/api.hpp
@@ -7,12 +7,12 @@
 
 #pragma once
 
-#include <jansson.h>
-#include <libwebsockets.h>
-
 #include <atomic>
 #include <list>
 #include <thread>
+
+#include <jansson.h>
+#include <libwebsockets.h>
 
 #include <villas/common.hpp>
 #include <villas/exceptions.hpp>

--- a/include/villas/api/request.hpp
+++ b/include/villas/api/request.hpp
@@ -7,9 +7,10 @@
 
 #pragma once
 
-#include <jansson.h>
 #include <regex>
 #include <vector>
+
+#include <jansson.h>
 
 #include <villas/api/session.hpp>
 #include <villas/buffer.hpp>

--- a/include/villas/config_class.hpp
+++ b/include/villas/config_class.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <cstdio>
-#include <jansson.h>
-#include <unistd.h>
-
 #include <filesystem>
 #include <functional>
 #include <regex>
+
+#include <jansson.h>
+#include <unistd.h>
 
 #include <villas/log.hpp>
 #include <villas/node/config.hpp>

--- a/include/villas/dumper.hpp
+++ b/include/villas/dumper.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <villas/log.hpp>
-
 #include <string>
+
+#include <villas/log.hpp>
 
 namespace villas {
 namespace node {

--- a/include/villas/kernel/nl.hpp
+++ b/include/villas/kernel/nl.hpp
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include <sys/socket.h>
-
 #include <netlink/netlink.h>
 #include <netlink/route/link.h>
 #include <netlink/route/route.h>
+#include <sys/socket.h>
 
 namespace villas {
 namespace kernel {

--- a/include/villas/kernel/tc.hpp
+++ b/include/villas/kernel/tc.hpp
@@ -14,10 +14,9 @@
 
 #include <cstdint>
 
+#include <jansson.h>
 #include <netlink/route/classifier.h>
 #include <netlink/route/qdisc.h>
-
-#include <jansson.h>
 
 namespace villas {
 namespace kernel {

--- a/include/villas/kernel/tc_netem.hpp
+++ b/include/villas/kernel/tc_netem.hpp
@@ -14,10 +14,9 @@
 
 #include <cstdint>
 
+#include <jansson.h>
 #include <netlink/route/classifier.h>
 #include <netlink/route/qdisc.h>
-
-#include <jansson.h>
 
 namespace villas {
 namespace kernel {

--- a/include/villas/mapping.hpp
+++ b/include/villas/mapping.hpp
@@ -7,8 +7,9 @@
 
 #pragma once
 
-#include <jansson.h>
 #include <memory>
+
+#include <jansson.h>
 
 #include <villas/common.hpp>
 #include <villas/node_list.hpp>

--- a/include/villas/node.h
+++ b/include/villas/node.h
@@ -7,9 +7,8 @@
 
 #pragma once
 
-#include <stdbool.h>
-
 #include <jansson.h>
+#include <stdbool.h>
 
 typedef void *vnode;
 typedef void *vsample;

--- a/include/villas/node.hpp
+++ b/include/villas/node.hpp
@@ -7,10 +7,12 @@
 
 #pragma once
 
-#include <fmt/ostream.h>
 #include <iostream>
+
+#include <fmt/ostream.h>
 #include <jansson.h>
 #include <uuid/uuid.h>
+
 #include <villas/colors.hpp>
 #include <villas/common.hpp>
 #include <villas/list.hpp>

--- a/include/villas/node_list.hpp
+++ b/include/villas/node_list.hpp
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <jansson.h>
-#include <uuid/uuid.h>
-
 #include <list>
 #include <string>
+
+#include <jansson.h>
+#include <uuid/uuid.h>
 
 namespace villas {
 namespace node {

--- a/include/villas/nodes/api.hpp
+++ b/include/villas/nodes/api.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <pthread.h>
+
 #include <villas/api/universal.hpp>
 #include <villas/node.hpp>
 

--- a/include/villas/nodes/fpga.hpp
+++ b/include/villas/nodes/fpga.hpp
@@ -10,16 +10,17 @@
 #pragma once
 
 #include <thread>
-#include <villas/format.hpp>
-#include <villas/node.hpp>
-#include <villas/node/config.hpp>
-#include <villas/timing.hpp>
 
 #include <stdint.h>
+
+#include <villas/format.hpp>
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/ips/dma.hpp>
 #include <villas/fpga/node.hpp>
 #include <villas/fpga/pcie_card.hpp>
+#include <villas/node.hpp>
+#include <villas/node/config.hpp>
+#include <villas/timing.hpp>
 
 namespace villas {
 namespace node {

--- a/include/villas/nodes/iec60870.hpp
+++ b/include/villas/nodes/iec60870.hpp
@@ -10,11 +10,13 @@
 #include <array>
 #include <cstdint>
 #include <ctime>
+#include <optional>
+#include <string>
+
 #include <lib60870/cs101_information_objects.h>
 #include <lib60870/cs104_slave.h>
 #include <lib60870/iec60870_common.h>
-#include <optional>
-#include <string>
+
 #include <villas/node.hpp>
 #include <villas/node/config.hpp>
 #include <villas/pool.hpp>

--- a/include/villas/nodes/iec61850.hpp
+++ b/include/villas/nodes/iec61850.hpp
@@ -9,11 +9,10 @@
 
 #include <cstdint>
 
-#include <netinet/ether.h>
-
 #include <libiec61850/goose_receiver.h>
 #include <libiec61850/hal_ethernet.h>
 #include <libiec61850/sv_subscriber.h>
+#include <netinet/ether.h>
 
 #include <villas/list.hpp>
 #include <villas/signal.hpp>

--- a/include/villas/nodes/infiniband.hpp
+++ b/include/villas/nodes/infiniband.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <netdb.h>
 #include <rdma/rdma_cma.h>
 
 #include <villas/format.hpp>
@@ -28,18 +29,18 @@ class NodeCompat;
 struct infiniband {
   // IBV/RDMA CM structs
   struct context_s {
-    struct rdma_cm_id *listen_id;
-    struct rdma_cm_id *id;
-    struct rdma_event_channel *ec;
+    ::rdma_cm_id *listen_id;
+    ::rdma_cm_id *id;
+    ::rdma_event_channel *ec;
 
-    struct ibv_pd *pd;
-    struct ibv_cq *recv_cq;
-    struct ibv_cq *send_cq;
-    struct ibv_comp_channel *comp_channel;
+    ::ibv_pd *pd;
+    ::ibv_cq *recv_cq;
+    ::ibv_cq *send_cq;
+    ::ibv_comp_channel *comp_channel;
   } ctx;
 
   // Queue Pair init variables
-  struct ibv_qp_init_attr qp_init;
+  ::ibv_qp_init_attr qp_init;
 
   // Size of receive and send completion queue
   int recv_cq_size;
@@ -54,17 +55,17 @@ struct infiniband {
 
   // Connection specific variables
   struct connection_s {
-    struct addrinfo *src_addr;
-    struct addrinfo *dst_addr;
+    ::addrinfo *src_addr;
+    ::addrinfo *dst_addr;
 
     // RDMA_PS_TCP or RDMA_PS_UDP
-    enum rdma_port_space port_space;
+    ::rdma_port_space port_space;
 
     // Timeout for rdma_resolve_route
     int timeout;
 
     // Thread to monitor RDMA CM Event threads
-    pthread_t rdma_cm_event_thread;
+    ::pthread_t rdma_cm_event_thread;
 
     // Bool, should data be send inline if possible?
     int send_inline;
@@ -81,10 +82,10 @@ struct infiniband {
 
     // Unrealiable connectionless data
     struct ud_s {
-      struct rdma_ud_param ud;
-      struct ibv_ah *ah;
+      ::rdma_ud_param ud;
+      ::ibv_ah *ah;
       void *grh_ptr;
-      struct ibv_mr *grh_mr;
+      ::ibv_mr *grh_mr;
     } ud;
 
   } conn;
@@ -97,7 +98,7 @@ int ib_reverse(NodeCompat *n);
 
 char *ib_print(NodeCompat *n);
 
-int ib_parse(NodeCompat *n, json_t *json);
+int ib_parse(NodeCompat *n, ::json_t *json);
 
 int ib_check(NodeCompat *n);
 

--- a/include/villas/nodes/modbus.hpp
+++ b/include/villas/nodes/modbus.hpp
@@ -10,11 +10,11 @@
 #include <algorithm>
 #include <numeric>
 #include <optional>
-#include <stdint.h>
 #include <variant>
 #include <vector>
 
 #include <modbus/modbus.h>
+#include <stdint.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/node.hpp>

--- a/include/villas/nodes/redis_helpers.hpp
+++ b/include/villas/nodes/redis_helpers.hpp
@@ -8,10 +8,12 @@
 #pragma once
 
 #include <chrono>
-#include <fmt/ostream.h>
 #include <functional>
+
+#include <fmt/ostream.h>
 #include <sw/redis++/connection.h>
 #include <sw/redis++/redis++.h>
+
 #include <villas/node/config.hpp>
 
 namespace std {

--- a/include/villas/nodes/rtp.hpp
+++ b/include/villas/nodes/rtp.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <pthread.h>
-
 #include <fstream>
+
+#include <pthread.h>
 
 #include <villas/dsp/pid.hpp>
 #include <villas/format.hpp>

--- a/include/villas/nodes/uldaq.hpp
+++ b/include/villas/nodes/uldaq.hpp
@@ -9,11 +9,10 @@
 #pragma once
 
 #include <pthread.h>
+#include <uldaq.h>
 
 #include <villas/pool.hpp>
 #include <villas/queue_signalled.h>
-
-#include <uldaq.h>
 
 #define ULDAQ_MAX_DEV_COUNT 100
 #define ULDAQ_MAX_RANGE_COUNT 8

--- a/include/villas/nodes/webrtc/peer_connection.hpp
+++ b/include/villas/nodes/webrtc/peer_connection.hpp
@@ -13,6 +13,7 @@
 #include <jansson.h>
 #include <rtc/peerconnection.hpp>
 #include <rtc/rtc.hpp>
+
 #include <villas/config.hpp>
 #include <villas/log.hpp>
 #include <villas/node/config.hpp>

--- a/include/villas/nodes/websocket.hpp
+++ b/include/villas/nodes/websocket.hpp
@@ -9,6 +9,7 @@
 
 #include <fmt/ostream.h>
 #include <libwebsockets.h>
+
 #include <villas/buffer.hpp>
 #include <villas/common.hpp>
 #include <villas/config.hpp>

--- a/include/villas/nodes/zeromq.hpp
+++ b/include/villas/nodes/zeromq.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include <jansson.h>
 
 #include <villas/format.hpp>

--- a/include/villas/path.hpp
+++ b/include/villas/path.hpp
@@ -13,6 +13,7 @@
 #include <jansson.h>
 #include <pthread.h>
 #include <uuid/uuid.h>
+
 #include <villas/colors.hpp>
 #include <villas/common.hpp>
 #include <villas/config.hpp>

--- a/include/villas/path_list.hpp
+++ b/include/villas/path_list.hpp
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <jansson.h>
-#include <uuid/uuid.h>
-
 #include <list>
 #include <string>
+
+#include <jansson.h>
+#include <uuid/uuid.h>
 
 namespace villas {
 namespace node {

--- a/include/villas/pool.hpp
+++ b/include/villas/pool.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstddef>
+
 #include <sys/types.h>
 
 #include <villas/common.hpp>

--- a/include/villas/queue.h
+++ b/include/villas/queue.h
@@ -34,9 +34,9 @@
 #pragma once
 
 #include <atomic>
-
 #include <cstddef>
 #include <cstdint>
+
 #include <unistd.h>
 
 #include <villas/common.hpp>

--- a/include/villas/sample.hpp
+++ b/include/villas/sample.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <atomic>
-
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>

--- a/include/villas/signal_data.hpp
+++ b/include/villas/signal_data.hpp
@@ -7,13 +7,12 @@
 
 #pragma once
 
-#include <jansson.h>
-
 #include <complex>
+#include <cstdint>
 #include <limits>
 #include <string>
 
-#include <cstdint>
+#include <jansson.h>
 
 #include <villas/signal_type.hpp>
 

--- a/include/villas/stats.hpp
+++ b/include/villas/stats.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <cstdint>
-#include <jansson.h>
-
 #include <memory>
 #include <string>
 #include <unordered_map>
+
+#include <jansson.h>
 
 #include <villas/common.hpp>
 #include <villas/hist.hpp>

--- a/include/villas/usb.hpp
+++ b/include/villas/usb.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <villas/exceptions.hpp>
-
 #include <libusb-1.0/libusb.h>
+
+#include <villas/exceptions.hpp>
 
 namespace villas {
 namespace usb {

--- a/lib/api/requests/node_file.cpp
+++ b/lib/api/requests/node_file.cpp
@@ -8,11 +8,10 @@
 #include <villas/api/requests/node.hpp>
 #include <villas/api/response.hpp>
 #include <villas/api/session.hpp>
-#include <villas/super_node.hpp>
-
 #include <villas/format.hpp>
 #include <villas/node_compat.hpp>
 #include <villas/nodes/file.hpp>
+#include <villas/super_node.hpp>
 
 namespace villas {
 namespace node {

--- a/lib/api/session.cpp
+++ b/lib/api/session.cpp
@@ -9,12 +9,11 @@
 
 #include <libwebsockets.h>
 
-#include <villas/node/memory.hpp>
-#include <villas/web.hpp>
-
 #include <villas/api/request.hpp>
 #include <villas/api/response.hpp>
 #include <villas/api/session.hpp>
+#include <villas/node/memory.hpp>
+#include <villas/web.hpp>
 
 using namespace villas;
 using namespace villas::node;

--- a/lib/capabilities.cpp
+++ b/lib/capabilities.cpp
@@ -5,9 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <villas/capabilities.hpp>
-
 #include <villas/api/request.hpp>
+#include <villas/capabilities.hpp>
 #include <villas/format.hpp>
 #include <villas/hook.hpp>
 #include <villas/plugin.hpp>

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <string>
+
 #include <glob.h>
 #include <libgen.h>
 #include <linux/limits.h>
 #include <unistd.h>
-
-#include <string>
 
 #include <villas/boxes.hpp>
 #include <villas/config_class.hpp>

--- a/lib/dumper.cpp
+++ b/lib/dumper.cpp
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cstring>
+#include <sstream>
+
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
-
-#include <cstring>
-#include <sstream>
 
 #include <villas/dumper.hpp>
 

--- a/lib/format.cpp
+++ b/lib/format.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
 #include <fcntl.h>
 
 #include <villas/exceptions.hpp>

--- a/lib/formats/villas_binary.cpp
+++ b/lib/formats/villas_binary.cpp
@@ -5,8 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arpa/inet.h>
 #include <cstring>
+
+#include <arpa/inet.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/formats/msg.hpp>

--- a/lib/formats/villas_human.cpp
+++ b/lib/formats/villas_human.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include <openssl/crypto.h>
+
 #include <villas/formats/villas_human.hpp>
 #include <villas/sample.hpp>
 #include <villas/signal.hpp>

--- a/lib/hooks/digest.cpp
+++ b/lib/hooks/digest.cpp
@@ -9,12 +9,12 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <fmt/core.h>
 #include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
 
+#include <fmt/core.h>
 #include <fmt/format.h>
 #include <openssl/evp.h>
 

--- a/lib/hooks/dp.cpp
+++ b/lib/hooks/dp.cpp
@@ -6,9 +6,8 @@
  */
 
 #include <cmath>
-#include <cstring>
-
 #include <complex>
+#include <cstring>
 
 #include <villas/dsp/window.hpp>
 #include <villas/hook.hpp>

--- a/lib/hooks/frame.cpp
+++ b/lib/hooks/frame.cpp
@@ -7,10 +7,12 @@
 
 #include <cstdint>
 #include <cstring>
-#include <jansson.h>
 #include <limits>
 #include <memory>
 #include <optional>
+
+#include <jansson.h>
+
 #include <villas/exceptions.hpp>
 #include <villas/hook.hpp>
 #include <villas/sample.hpp>

--- a/lib/hooks/pmu_dft.cpp
+++ b/lib/hooks/pmu_dft.cpp
@@ -8,11 +8,11 @@
 #include <complex>
 #include <cstring>
 #include <vector>
-#include <villas/timing.hpp>
 
 #include <villas/dumper.hpp>
 #include <villas/hook.hpp>
 #include <villas/sample.hpp>
+#include <villas/timing.hpp>
 
 // Uncomment to enable dumper of memory windows
 //#define DFT_MEM_DUMP

--- a/lib/hooks/reorder_ts.cpp
+++ b/lib/hooks/reorder_ts.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "villas/exceptions.hpp"
 #include <algorithm>
 #include <cstring>
 #include <ctime>
@@ -14,6 +13,8 @@
 #include <villas/hook.hpp>
 #include <villas/sample.hpp>
 #include <villas/timing.hpp>
+
+#include "villas/exceptions.hpp"
 
 namespace villas {
 namespace node {

--- a/lib/kernel/if.cpp
+++ b/lib/kernel/if.cpp
@@ -7,23 +7,21 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <dirent.h>
 
+#include <dirent.h>
 #include <netlink/route/link.h>
 
 #include <villas/cpuset.hpp>
 #include <villas/exceptions.hpp>
-#include <villas/node/config.hpp>
-#include <villas/super_node.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/kernel/if.hpp>
 #include <villas/kernel/kernel.hpp>
 #include <villas/kernel/nl.hpp>
 #include <villas/kernel/tc.hpp>
 #include <villas/kernel/tc_netem.hpp>
-
+#include <villas/node/config.hpp>
 #include <villas/nodes/socket.hpp>
+#include <villas/super_node.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas;
 using namespace villas::node;

--- a/lib/kernel/nl.cpp
+++ b/lib/kernel/nl.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <linux/if_packet.h>
-
 #include <netlink/route/link.h>
 #include <netlink/route/route.h>
 

--- a/lib/kernel/tc.cpp
+++ b/lib/kernel/tc.cpp
@@ -7,10 +7,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <linux/if_ether.h>
 #include <netlink/route/cls/fw.h>
 #include <netlink/route/qdisc/prio.h>
-
-#include <linux/if_ether.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/kernel/if.hpp>

--- a/lib/kernel/tc_netem.cpp
+++ b/lib/kernel/tc_netem.cpp
@@ -8,8 +8,8 @@
  */
 
 #include <cmath>
-#include <jansson.h>
 
+#include <jansson.h>
 #include <netlink/route/qdisc/netem.h>
 
 #include <villas/exceptions.hpp>

--- a/lib/memory.cpp
+++ b/lib/memory.cpp
@@ -5,17 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <unordered_map>
-
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include <malloc.h>
-#include <unistd.h>
+#include <unordered_map>
 
+#include <malloc.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/kernel/kernel.hpp>

--- a/lib/memory/managed.cpp
+++ b/lib/memory/managed.cpp
@@ -6,13 +6,13 @@
  */
 
 #include <cstdlib>
-#include <strings.h>
-#include <unistd.h>
 
+#include <strings.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/log.hpp>

--- a/lib/memory/mmap.cpp
+++ b/lib/memory/mmap.cpp
@@ -6,12 +6,12 @@
  */
 
 #include <cstdlib>
-#include <unistd.h>
 
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 // Required to allocate hugepages on Apple OS X
 #ifdef __MACH__

--- a/lib/node.cpp
+++ b/lib/node.cpp
@@ -5,8 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <openssl/md5.h>
 #include <regex>
+
+#include <openssl/md5.h>
 
 #ifdef __linux__
 extern "C" {

--- a/lib/nodes/can.cpp
+++ b/lib/nodes/can.cpp
@@ -8,16 +8,15 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <unistd.h>
-
-#include <net/if.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
 #include <linux/sockios.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/node_compat.hpp>

--- a/lib/nodes/comedi.cpp
+++ b/lib/nodes/comedi.cpp
@@ -7,9 +7,10 @@
  */
 
 #include <cmath>
+#include <cstring>
+
 #include <comedi_errno.h>
 #include <comedilib.h>
-#include <cstring>
 #include <sys/mman.h>
 
 #include <villas/exceptions.hpp>

--- a/lib/nodes/exec.cpp
+++ b/lib/nodes/exec.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <string>
+
 #include <unistd.h>
 
 #include <villas/format.hpp>

--- a/lib/nodes/file.cpp
+++ b/lib/nodes/file.cpp
@@ -7,6 +7,7 @@
 
 #include <cerrno>
 #include <cstring>
+
 #include <libgen.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/lib/nodes/fpga.cpp
+++ b/lib/nodes/fpga.cpp
@@ -7,24 +7,23 @@
 
 #include <memory>
 #include <string>
-#include <unistd.h>
 #include <vector>
 
 #include <jansson.h>
+#include <unistd.h>
 
 #include <villas/exceptions.hpp>
+#include <villas/fpga/ips/dino.hpp>
+#include <villas/fpga/ips/register.hpp>
+#include <villas/fpga/ips/switch.hpp>
+#include <villas/fpga/pcie_card.hpp>
+#include <villas/fpga/utils.hpp>
 #include <villas/log.hpp>
 #include <villas/memory.hpp>
 #include <villas/nodes/fpga.hpp>
 #include <villas/sample.hpp>
 #include <villas/super_node.hpp>
 #include <villas/utils.hpp>
-
-#include <villas/fpga/ips/dino.hpp>
-#include <villas/fpga/ips/register.hpp>
-#include <villas/fpga/ips/switch.hpp>
-#include <villas/fpga/pcie_card.hpp>
-#include <villas/fpga/utils.hpp>
 
 using namespace villas;
 using namespace villas::node;

--- a/lib/nodes/iec61850.cpp
+++ b/lib/nodes/iec61850.cpp
@@ -5,10 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <unistd.h>
-
 #include <libiec61850/goose_receiver.h>
 #include <libiec61850/sv_subscriber.h>
+#include <unistd.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/node_compat.hpp>

--- a/lib/nodes/iec61850_sv.cpp
+++ b/lib/nodes/iec61850_sv.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <libiec61850/sv_publisher.h>
 #include <libiec61850/sv_subscriber.h>
 #include <net/ethernet.h>

--- a/lib/nodes/infiniband.cpp
+++ b/lib/nodes/infiniband.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstring>
+
 #include <netdb.h>
 
 #include <villas/exceptions.hpp>

--- a/lib/nodes/influxdb.cpp
+++ b/lib/nodes/influxdb.cpp
@@ -7,6 +7,7 @@
 
 #include <cinttypes>
 #include <cstring>
+
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/lib/nodes/kafka.cpp
+++ b/lib/nodes/kafka.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <librdkafka/rdkafkacpp.h>
 #include <sys/syslog.h>
 

--- a/lib/nodes/nanomsg.cpp
+++ b/lib/nodes/nanomsg.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <nanomsg/nn.h>
 #include <nanomsg/pubsub.h>
 

--- a/lib/nodes/opendss.cpp
+++ b/lib/nodes/opendss.cpp
@@ -5,7 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// clang-format off
+// OpenDSS has broken header files that conflict with std::complex
 #include <OpenDSSCDLL.h>
+// clang-format on
+
 #include <fmt/core.h>
 
 #include <villas/exceptions.hpp>

--- a/lib/nodes/rtp.cpp
+++ b/lib/nodes/rtp.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <ctime>
+
 #include <pthread.h>
 #include <signal.h>
 

--- a/lib/nodes/shmem.cpp
+++ b/lib/nodes/shmem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <fcntl.h>
 #include <pthread.h>
 #include <sys/mman.h>

--- a/lib/nodes/socket.cpp
+++ b/lib/nodes/socket.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arpa/inet.h>
 #include <cerrno>
 #include <cstring>
+
+#include <arpa/inet.h>
 #include <netinet/ip.h>
 #include <unistd.h>
 

--- a/lib/nodes/test_rtt.cpp
+++ b/lib/nodes/test_rtt.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <cstring>
+
 #include <linux/limits.h>
 #include <sys/stat.h>
 

--- a/lib/nodes/webrtc/peer_connection.cpp
+++ b/lib/nodes/webrtc/peer_connection.cpp
@@ -14,6 +14,7 @@
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <rtc/common.hpp>
+
 #include <villas/exceptions.hpp>
 #include <villas/nodes/webrtc/peer_connection.hpp>
 #include <villas/utils.hpp>

--- a/lib/nodes/webrtc/signaling_message.cpp
+++ b/lib/nodes/webrtc/signaling_message.cpp
@@ -8,7 +8,9 @@
  */
 
 #include <algorithm>
+
 #include <fmt/format.h>
+
 #include <villas/exceptions.hpp>
 #include <villas/nodes/webrtc/signaling_message.hpp>
 #include <villas/utils.hpp>

--- a/lib/nodes/websocket.cpp
+++ b/lib/nodes/websocket.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
 #include <unistd.h>
 
 #include <villas/exceptions.hpp>

--- a/lib/nodes/zeromq.cpp
+++ b/lib/nodes/zeromq.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+
 #include <zmq.h>
 
 #if ZMQ_VERSION_MAJOR < 4 || (ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR <= 1)

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -5,10 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
-
-#include <algorithm>
 #include <map>
 
 #include <poll.h>

--- a/lib/path_source.cpp
+++ b/lib/path_source.cpp
@@ -10,14 +10,12 @@
 #include <villas/exceptions.hpp>
 #include <villas/hook_list.hpp>
 #include <villas/node.hpp>
-#include <villas/path.hpp>
-#include <villas/sample.hpp>
-#include <villas/utils.hpp>
-
 #include <villas/nodes/loopback_internal.hpp>
-
+#include <villas/path.hpp>
 #include <villas/path_destination.hpp>
 #include <villas/path_source.hpp>
+#include <villas/sample.hpp>
+#include <villas/utils.hpp>
 
 using namespace villas;
 using namespace villas::node;

--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cerrno>
+
 #include <fcntl.h>
 #include <semaphore.h>
 #include <sys/mman.h>

--- a/lib/socket_addr.cpp
+++ b/lib/socket_addr.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arpa/inet.h>
 #include <cstdlib>
 #include <cstring>
+
+#include <arpa/inet.h>
 #include <netdb.h>
 
 #include <villas/exceptions.hpp>

--- a/src/villas-compare.cpp
+++ b/src/villas-compare.cpp
@@ -6,9 +6,9 @@
  */
 
 #include <iostream>
-#include <unistd.h>
 
 #include <jansson.h>
+#include <unistd.h>
 
 #include <villas/exceptions.hpp>
 #include <villas/format.hpp>

--- a/src/villas-conf2json.cpp
+++ b/src/villas-conf2json.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+
 #include <jansson.h>
 #include <libconfig.h>
 #include <libgen.h>

--- a/src/villas-convert.cpp
+++ b/src/villas-convert.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+
 #include <unistd.h>
 
 #include <villas/exceptions.hpp>

--- a/src/villas-graph.cpp
+++ b/src/villas-graph.cpp
@@ -7,9 +7,10 @@
 
 #include <iostream>
 
+// clang-format off
 #include <graphviz/types.h>
-
 #include <graphviz/gvcommon.h>
+// clang-format on
 
 #include <villas/super_node.hpp>
 #include <villas/tool.hpp>

--- a/src/villas-hook.cpp
+++ b/src/villas-hook.cpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <iostream>
+
 #include <unistd.h>
 
 #include <villas/colors.hpp>

--- a/src/villas-node.cpp
+++ b/src/villas-node.cpp
@@ -6,10 +6,10 @@
  */
 
 #include <cstdlib>
-#include <unistd.h>
-
 #include <iomanip>
 #include <iostream>
+
+#include <unistd.h>
 
 #include <villas/api.hpp>
 #include <villas/api/request.hpp>

--- a/src/villas-pipe.cpp
+++ b/src/villas-pipe.cpp
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <cstdlib>
-#include <signal.h>
-#include <unistd.h>
-
 #include <atomic>
+#include <cstdlib>
 #include <iostream>
 #include <thread>
+
+#include <signal.h>
+#include <unistd.h>
 
 #include <villas/colors.hpp>
 #include <villas/config_helper.hpp>

--- a/src/villas-relay.cpp
+++ b/src/villas-relay.cpp
@@ -5,13 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cstring>
 #include <iostream>
 #include <map>
 #include <queue>
 #include <string>
 #include <utility>
-
-#include <cstring>
 
 #include <jansson.h>
 #include <unistd.h>

--- a/src/villas-relay.hpp
+++ b/src/villas-relay.hpp
@@ -5,14 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <map>
 #include <memory>
+#include <queue>
 #include <vector>
 
+#include <libwebsockets.h>
 #include <uuid/uuid.h>
 
-#include <libwebsockets.h>
-
 #include <villas/log.hpp>
+#include <villas/tool.hpp>
 
 namespace villas {
 namespace node {

--- a/src/villas-signal.cpp
+++ b/src/villas-signal.cpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <iostream>
+
 #include <unistd.h>
 
 #include <villas/colors.hpp>

--- a/src/villas-test-config.cpp
+++ b/src/villas-test-config.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+
 #include <unistd.h>
 
 #include <villas/log.hpp>

--- a/src/villas-zmq-keygen.cpp
+++ b/src/villas-zmq-keygen.cpp
@@ -7,8 +7,10 @@
 
 #include <cstdlib>
 #include <iostream>
-#include <villas/tool.hpp>
+
 #include <zmq.h>
+
+#include <villas/tool.hpp>
 
 #if ZMQ_VERSION_MAJOR < 4 || (ZMQ_VERSION_MAJOR == 4 && ZMQ_VERSION_MINOR <= 1)
 #include <zmq_utils.h>

--- a/tests/unit/config.cpp
+++ b/tests/unit/config.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <criterion/criterion.h>
 #include <cstdio>
 #include <cstdlib>
+
+#include <criterion/criterion.h>
 
 #include <villas/config_class.hpp>
 #include <villas/utils.hpp>

--- a/tests/unit/format.cpp
+++ b/tests/unit/format.cpp
@@ -6,11 +6,11 @@
  */
 
 #include <complex>
-#include <float.h>
-#include <stdio.h>
 
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
+#include <float.h>
+#include <stdio.h>
 
 #include <villas/format.hpp>
 #include <villas/log.hpp>

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cerrno>
+
 #include <criterion/criterion.h>
 #include <criterion/theories.h>
-
-#include <cerrno>
 
 #include <villas/log.hpp>
 #include <villas/node/memory.hpp>

--- a/tests/unit/pool.cpp
+++ b/tests/unit/pool.cpp
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <vector>
+
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
-
 #include <signal.h>
-#include <vector>
 
 #include <villas/log.hpp>
 #include <villas/pool.hpp>

--- a/tests/unit/queue.cpp
+++ b/tests/unit/queue.cpp
@@ -8,12 +8,12 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
-#include <pthread.h>
-#include <stdio.h>
-#include <unistd.h>
 
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
 
 #include <villas/log.hpp>
 #include <villas/node/memory.hpp>

--- a/tests/unit/queue_signalled.cpp
+++ b/tests/unit/queue_signalled.cpp
@@ -7,7 +7,6 @@
 
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
-
 #include <poll.h>
 #include <pthread.h>
 


### PR DESCRIPTION
This instructs `clang-format` to enforce a uniform `#include` order across all files. See https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includecategories

1. `^<villas/`: headers
2. `^<[[:lower:]]+>$`: standard library headers
3. `^<.*>$`: other system headers 
4. `^".*"$`: local headers