### PR TITLE
Change method of python api restart node request to POST instead of default GET

### DIFF
--- a/python/villas/node/node.py
+++ b/python/villas/node/node.py
@@ -93,7 +93,7 @@ class Node(object):
 
     def restart(self):
         LOGGER.info("Restarting VILLASnode instance")
-        self.request("restart")
+        self.request("restart", method="POST")
 
     @property
     def active_config(self):


### PR DESCRIPTION
Otherwise results in
```
07:27:46 warn api:session API request failed: endpoint=restart, method=GET, code=400: The 'restart' API endpoint does not support GET requests
```
In villasnode
Maybe it is recommended to just use load_config instead and remove this entirely ?