### PR TITLE
Fix stats print on ARM due to indeterminate state of "va_list" parameter after vasprintf (take 2)

### DIFF
--- a/common/include/villas/log.hpp
+++ b/common/include/villas/log.hpp
@@ -54,7 +54,7 @@ public:
   Log(Level level = Level::info);
 
   // Get the real usable log output width which fits into one line.
-  int getWidth();
+  static int getWidth();
 
   void parse(json_t *json);
 

--- a/common/include/villas/log.hpp
+++ b/common/include/villas/log.hpp
@@ -54,7 +54,7 @@ public:
   Log(Level level = Level::info);
 
   // Get the real usable log output width which fits into one line.
-  static int getWidth();
+  int getWidth();
 
   void parse(json_t *json);
 

--- a/common/include/villas/table.hpp
+++ b/common/include/villas/table.hpp
@@ -28,13 +28,14 @@ public:
 protected:
   int _width; // The real width of this column. Calculated by Table::resize().
 
-  int width; // Width of the column.
+  int width;     // Width of the column.
   int precision; // Precision of the column, used for floating point values.
 
 public:
   TableColumn(int w, int p, enum Alignment a, const std::string &t,
               const std::string &f, const std::string &u = "")
-      : _width(0), width(w), precision(p), title(t), format(f), unit(u), align(a) {}
+      : _width(0), width(w), precision(p), title(t), format(f), unit(u),
+        align(a) {}
 
   std::string title;  // The title as shown in the table header.
   std::string format; // The format which is used to print the table rows.
@@ -65,8 +66,7 @@ public:
   void header();
 
   // Print table rows.
-  template <class... Args>
-  void row(const Args&... args) {
+  template <class... Args> void row(const Args &...args) {
     auto logWidth = Log::getWidth();
     if (width != logWidth) {
       resize(logWidth);

--- a/common/include/villas/table.hpp
+++ b/common/include/villas/table.hpp
@@ -67,13 +67,13 @@ public:
 
   // Print table rows.
   template <class... Args> void row(const Args &...args) {
-    auto logWidth = Log::getWidth();
+    auto logWidth = Log::getInstance().getWidth();
     if (width != logWidth) {
       resize(logWidth);
       header();
     }
 
-    logger->info(rowFormat, args...);
+    logger->info(fmt::runtime(rowFormat), args...);
   }
 
   int getWidth() const { return width; }

--- a/common/include/villas/table.hpp
+++ b/common/include/villas/table.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <fmt/printf.h>
+
 #include <villas/log.hpp>
 
 namespace villas {
@@ -63,7 +65,16 @@ public:
   void header();
 
   // Print table rows.
-  void row(int count, ...);
+  template <class... Args>
+  void row(const Args&... args) {
+    auto logWidth = Log::getWidth();
+    if (width != logWidth) {
+      resize(logWidth);
+      header();
+    }
+
+    logger->info(rowFormat, args...);
+  }
 
   int getWidth() const { return width; }
 };

--- a/common/include/villas/table.hpp
+++ b/common/include/villas/table.hpp
@@ -27,11 +27,12 @@ protected:
   int _width; // The real width of this column. Calculated by Table::resize().
 
   int width; // Width of the column.
+  int precision; // Precision of the column, used for floating point values.
 
 public:
-  TableColumn(int w, enum Alignment a, const std::string &t,
+  TableColumn(int w, int p, enum Alignment a, const std::string &t,
               const std::string &f, const std::string &u = "")
-      : _width(0), width(w), title(t), format(f), unit(u), align(a) {}
+      : _width(0), width(w), precision(p), title(t), format(f), unit(u), align(a) {}
 
   std::string title;  // The title as shown in the table header.
   std::string format; // The format which is used to print the table rows.
@@ -46,10 +47,11 @@ class Table {
 
 protected:
   int resize(int w);
+  void updateRowFormat();
 
   int width;
-
   std::vector<TableColumn> columns;
+  std::string rowFormat;
 
   Logger logger;
 

--- a/common/lib/hist.cpp
+++ b/common/lib/hist.cpp
@@ -130,7 +130,7 @@ void Hist::plot(Logger logger) const {
 
   std::vector<TableColumn> cols = {
       {-9, 3, TableColumn::Alignment::RIGHT, "Value", "g"},
-      {-6, -1, TableColumn::Alignment::RIGHT, "Count", "ju"},
+      {-6, -1, TableColumn::Alignment::RIGHT, "Count", "d"},
       {0, -1, TableColumn::Alignment::LEFT, "Plot", "s", "occurrences"}};
 
   Table table = Table(logger, cols);
@@ -147,7 +147,7 @@ void Hist::plot(Logger logger) const {
     for (int i = 0; i < bar; i++)
       buf = strcatf(&buf, "\u2588");
 
-    table.row(3, value, cnt, buf);
+    table.row(value, cnt, buf);
 
     free(buf);
   }

--- a/common/lib/hist.cpp
+++ b/common/lib/hist.cpp
@@ -129,9 +129,9 @@ void Hist::plot(Logger logger) const {
   Hist::cnt_t max = *std::max_element(data.begin(), data.end());
 
   std::vector<TableColumn> cols = {
-      {-9, TableColumn::Alignment::RIGHT, "Value", "%+9.3g"},
-      {-6, TableColumn::Alignment::RIGHT, "Count", "%6ju"},
-      {0, TableColumn::Alignment::LEFT, "Plot", "%s", "occurrences"}};
+      {-9, 3, TableColumn::Alignment::RIGHT, "Value", "g"},
+      {-6, -1, TableColumn::Alignment::RIGHT, "Count", "ju"},
+      {0, -1, TableColumn::Alignment::LEFT, "Plot", "s", "occurrences"}};
 
   Table table = Table(logger, cols);
 

--- a/common/lib/log.cpp
+++ b/common/lib/log.cpp
@@ -65,7 +65,7 @@ int Log::getWidth() {
   width -= 1;  // Space
   width -= 16; // Name
   width -= 1;  // Space
-  width -= getInstance().prefix.length();
+  width -= prefix.length();
 
   return width;
 }

--- a/common/lib/log.cpp
+++ b/common/lib/log.cpp
@@ -59,12 +59,12 @@ Log::Log(Level lvl) : level(lvl), pattern("%H:%M:%S %^%-4t%$ %-16n %v") {
 int Log::getWidth() {
   int width = Terminal::getCols();
 
-  width -= 8; // Timestamp
-  width -= 1; // Space
-  width -= 4; // Level
-  width -= 1; // Space
+  width -= 8;  // Timestamp
+  width -= 1;  // Space
+  width -= 4;  // Level
+  width -= 1;  // Space
   width -= 16; // Name
-  width -= 1; // Space
+  width -= 1;  // Space
   width -= getInstance().prefix.length();
 
   return width;

--- a/common/lib/log.cpp
+++ b/common/lib/log.cpp
@@ -57,10 +57,15 @@ Log::Log(Level lvl) : level(lvl), pattern("%H:%M:%S %^%-4t%$ %-16n %v") {
 }
 
 int Log::getWidth() {
-  int width = Terminal::getCols() - 50;
+  int width = Terminal::getCols();
 
-  if (!prefix.empty())
-    width -= prefix.length();
+  width -= 8; // Timestamp
+  width -= 1; // Space
+  width -= 4; // Level
+  width -= 1; // Space
+  width -= 16; // Name
+  width -= 1; // Space
+  width -= getInstance().prefix.length();
 
   return width;
 }

--- a/common/lib/table.cpp
+++ b/common/lib/table.cpp
@@ -94,7 +94,7 @@ void Table::updateRowFormat() {
     rowFormat += "}";
 
     if (i != columns.size() - 1) {
-      rowFormat += "} " BOX_UD;
+      rowFormat += BOX_UD;
     }
   }
 }

--- a/common/lib/table.cpp
+++ b/common/lib/table.cpp
@@ -33,7 +33,7 @@ int Table::resize(int w) {
   float total = width - columns.size() * 3; // Column separators and whitespace
 
   // Normalize width
-  for (auto &column: columns) {
+  for (auto &column : columns) {
     if (column.width > 0) {
       norm += column.width;
     } else if (column.width == 0) {
@@ -45,10 +45,10 @@ int Table::resize(int w) {
 
   int total_used = 0;
 
-  for (auto &column: columns) {
+  for (auto &column : columns) {
     if (column.width > 0) {
       column._width = column.width * (total - fixed) / norm;
-    } else if (column.width == 0){
+    } else if (column.width == 0) {
       column._width = (total - fixed) / flex;
     } else if (column.width < 0) {
       column._width = -1 * column.width;
@@ -58,7 +58,7 @@ int Table::resize(int w) {
   }
 
   // Distribute remaining space over flex columns
-  for (auto &column: columns) {
+  for (auto &column : columns) {
     if (total_used >= total) {
       break;
     }
@@ -80,7 +80,7 @@ void Table::updateRowFormat() {
   for (unsigned i = 0; i < columns.size(); ++i) {
     auto &column = columns[i];
 
-    rowFormat += " {:" ;
+    rowFormat += " {:";
     rowFormat += column.align == TableColumn::Alignment::LEFT ? "<" : ">";
     rowFormat += std::to_string(column._width);
 
@@ -113,8 +113,12 @@ void Table::header() {
     auto &column = columns[i];
 
     auto leftAligned = column.align == TableColumn::Alignment::LEFT;
-    line1 += fmt::format(leftAligned ? CLR_BLD(" {0:<{1}.{1}s}") : CLR_BLD(" {0:>{1}.{1}s}"), column.title, column._width);
-    line2 += fmt::format(leftAligned ? CLR_YEL(" {0:<{1}.{1}s}") : CLR_YEL(" {0:>{1}.{1}s}"), column.unit, column._width);
+    line1 += fmt::format(leftAligned ? CLR_BLD(" {0:<{1}.{1}s}")
+                                     : CLR_BLD(" {0:>{1}.{1}s}"),
+                         column.title, column._width);
+    line2 += fmt::format(leftAligned ? CLR_YEL(" {0:<{1}.{1}s}")
+                                     : CLR_YEL(" {0:>{1}.{1}s}"),
+                         column.unit, column._width);
 
     for (int j = 0; j < column._width + 2; j++) {
       line3 += BOX_LR;

--- a/common/lib/table.cpp
+++ b/common/lib/table.cpp
@@ -100,7 +100,7 @@ void Table::updateRowFormat() {
 }
 
 void Table::header() {
-  auto logWidth = Log::getWidth();
+  auto logWidth = Log::getInstance().getWidth();
   if (width != logWidth) {
     resize(logWidth);
   }
@@ -108,6 +108,9 @@ void Table::header() {
   std::string line1;
   std::string line2;
   std::string line3;
+  line1.reserve(width);
+  line2.reserve(width);
+  line3.reserve(width);
 
   for (unsigned i = 0; i < columns.size(); i++) {
     auto &column = columns[i];
@@ -131,7 +134,7 @@ void Table::header() {
     }
   }
 
-  logger->info(line1);
-  logger->info(line2);
-  logger->info(line3);
+  logger->info("{}", line1);
+  logger->info("{}", line2);
+  logger->info("{}", line3);
 }

--- a/etc/examples/hooks/stats.conf
+++ b/etc/examples/hooks/stats.conf
@@ -1,28 +1,31 @@
 # SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
+stats = 1
+
 nodes = {
-    udp_node = {
-        type = "socket"
+    signal_node = {
+        type = "signal"
+        signal = "mixed"
+        values = 5
+        rate = 50
 
         in = {
-            address = "*:12000"
-
             hooks = (
                 {
                     type = "stats"
 
                     verbose = true
-                    warmup = 100
+                    warmup = 10
                     buckets = 25
-
-                    output = "stats.log"
-                    format = "json"
                 }
             )
         }
-        out = {
-            address = "127.0.0.1:12000"
-        }
     }
 }
+
+paths = (
+    {
+        in = "signal_node"
+    }
+)

--- a/lib/stats.cpp
+++ b/lib/stats.cpp
@@ -62,7 +62,7 @@ std::vector<TableColumn> Stats::columns = {
     {10, -1, TableColumn::Alignment::RIGHT, "Rate mean", "f", "pkt/sec"},
     {10, -1, TableColumn::Alignment::RIGHT, "Age mean", "f", "secs"},
     {10, -1, TableColumn::Alignment::RIGHT, "Age Max", "f", "sec"},
-    {-7,  -1, TableColumn::Alignment::RIGHT, "Signals", "d", "signals"}};
+    {-7, -1, TableColumn::Alignment::RIGHT, "Signals", "d", "signals"}};
 
 enum Stats::Format Stats::lookupFormat(const std::string &str) {
   if (str == "human")

--- a/lib/stats.cpp
+++ b/lib/stats.cpp
@@ -52,17 +52,17 @@ std::unordered_map<Stats::Type, Stats::TypeDescription> Stats::types = {
 
 std::vector<TableColumn> Stats::columns = {
     {10, -1, TableColumn::Alignment::LEFT, "Node", "s"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Recv", "ju", "pkts"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Sent", "ju", "pkts"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Drop", "ju", "pkts"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Skip", "ju", "pkts"},
-    {10, -1, TableColumn::Alignment::RIGHT, "OWD last", "lf", "secs"},
-    {10, -1, TableColumn::Alignment::RIGHT, "OWD mean", "lf", "secs"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Rate last", "lf", "pkt/sec"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Rate mean", "lf", "pkt/sec"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Age mean", "lf", "secs"},
-    {10, -1, TableColumn::Alignment::RIGHT, "Age Max", "lf", "sec"},
-    {-7,  -1, TableColumn::Alignment::RIGHT, "Signals", "ju", "signals"}};
+    {10, -1, TableColumn::Alignment::RIGHT, "Recv", "d", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Sent", "d", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Drop", "d", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Skip", "d", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "OWD last", "f", "secs"},
+    {10, -1, TableColumn::Alignment::RIGHT, "OWD mean", "f", "secs"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Rate last", "f", "pkt/sec"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Rate mean", "f", "pkt/sec"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Age mean", "f", "secs"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Age Max", "f", "sec"},
+    {-7,  -1, TableColumn::Alignment::RIGHT, "Signals", "d", "signals"}};
 
 enum Stats::Format Stats::lookupFormat(const std::string &str) {
   if (str == "human")
@@ -142,7 +142,7 @@ void Stats::printPeriodic(FILE *f, enum Format fmt, node::Node *n) const {
   switch (fmt) {
   case Format::HUMAN:
     setupTable();
-    table->row(11, n->getNameShort().c_str(),
+    table->row(n->getNameShort(),
                (uintmax_t)histograms.at(Metric::OWD).getTotal(),
                (uintmax_t)histograms.at(Metric::AGE).getTotal(),
                (uintmax_t)histograms.at(Metric::SMPS_REORDERED).getTotal(),

--- a/lib/stats.cpp
+++ b/lib/stats.cpp
@@ -62,7 +62,7 @@ std::vector<TableColumn> Stats::columns = {
     {10, -1, TableColumn::Alignment::RIGHT, "Rate mean", "lf", "pkt/sec"},
     {10, -1, TableColumn::Alignment::RIGHT, "Age mean", "lf", "secs"},
     {10, -1, TableColumn::Alignment::RIGHT, "Age Max", "lf", "sec"},
-    {8,  -1, TableColumn::Alignment::RIGHT, "Signals", "ju", "signals"}};
+    {-7,  -1, TableColumn::Alignment::RIGHT, "Signals", "ju", "signals"}};
 
 enum Stats::Format Stats::lookupFormat(const std::string &str) {
   if (str == "human")

--- a/lib/stats.cpp
+++ b/lib/stats.cpp
@@ -51,18 +51,18 @@ std::unordered_map<Stats::Type, Stats::TypeDescription> Stats::types = {
     {Stats::Type::TOTAL, {"total", SignalType::INTEGER}}};
 
 std::vector<TableColumn> Stats::columns = {
-    {10, TableColumn::Alignment::LEFT, "Node", "%s"},
-    {10, TableColumn::Alignment::RIGHT, "Recv", "%ju", "pkts"},
-    {10, TableColumn::Alignment::RIGHT, "Sent", "%ju", "pkts"},
-    {10, TableColumn::Alignment::RIGHT, "Drop", "%ju", "pkts"},
-    {10, TableColumn::Alignment::RIGHT, "Skip", "%ju", "pkts"},
-    {10, TableColumn::Alignment::RIGHT, "OWD last", "%lf", "secs"},
-    {10, TableColumn::Alignment::RIGHT, "OWD mean", "%lf", "secs"},
-    {10, TableColumn::Alignment::RIGHT, "Rate last", "%lf", "pkt/sec"},
-    {10, TableColumn::Alignment::RIGHT, "Rate mean", "%lf", "pkt/sec"},
-    {10, TableColumn::Alignment::RIGHT, "Age mean", "%lf", "secs"},
-    {10, TableColumn::Alignment::RIGHT, "Age Max", "%lf", "sec"},
-    {8, TableColumn::Alignment::RIGHT, "Signals", "%ju", "signals"}};
+    {10, -1, TableColumn::Alignment::LEFT, "Node", "s"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Recv", "ju", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Sent", "ju", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Drop", "ju", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Skip", "ju", "pkts"},
+    {10, -1, TableColumn::Alignment::RIGHT, "OWD last", "lf", "secs"},
+    {10, -1, TableColumn::Alignment::RIGHT, "OWD mean", "lf", "secs"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Rate last", "lf", "pkt/sec"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Rate mean", "lf", "pkt/sec"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Age mean", "lf", "secs"},
+    {10, -1, TableColumn::Alignment::RIGHT, "Age Max", "lf", "sec"},
+    {8,  -1, TableColumn::Alignment::RIGHT, "Signals", "ju", "signals"}};
 
 enum Stats::Format Stats::lookupFormat(const std::string &str) {
   if (str == "human")


### PR DESCRIPTION
This is another take on #933 / #678.

I think, I found a nice approach by pre-building the format string for a whole table row ince during the initialization. That allows us to use a single `vsprintf` call to format the whole row.

What do you think?

I also tweaked the table rendering a bit to fix some miscalculated column width.

Closes #678