### PR TITLE
Fix member function call on null-pointer instance of `SignalingClient`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,7 @@
             boxfort
             clang-tools
             criterion
+            gdb
             jq
             libffi
             libgit2

--- a/include/villas/nodes/webrtc/signaling_client.hpp
+++ b/include/villas/nodes/webrtc/signaling_client.hpp
@@ -73,9 +73,6 @@ protected:
 
   Logger logger;
 
-  int protocolCallback(struct lws *wsi, enum lws_callback_reasons reason,
-                       void *in, size_t len);
-
   static void connectStatic(struct lws_sorted_usec_list *sul);
 
   int writable();
@@ -85,9 +82,8 @@ public:
                   const std::string &peer, Web *w);
   ~SignalingClient();
 
-  static int protocolCallbackStatic(struct lws *wsi,
-                                    enum lws_callback_reasons reason,
-                                    void *user, void *in, size_t len);
+  static int protocolCallback(struct lws *wsi, enum lws_callback_reasons reason,
+                              void *user, void *in, size_t len);
 
   void connect();
   void disconnect();

--- a/lib/web.cpp
+++ b/lib/web.cpp
@@ -46,8 +46,7 @@ lws_protocols protocols[] = {
 #endif // WITH_NODE_WEBSOCKET
 #ifdef WITH_NODE_WEBRTC
     {.name = "webrtc-signaling",
-     .callback = webrtc::SignalingClient::protocolCallbackStatic,
-     .per_session_data_size = sizeof(webrtc::SignalingClient),
+     .callback = webrtc::SignalingClient::protocolCallback,
      .rx_buffer_size = 0},
 #endif
     {


### PR DESCRIPTION
# Bug

`libwebsockets` calls the protocol callbacks for our webrtc signaling client even when the connection is not explicitly initiated from the signaling client code. This causes the `protocolCallbackStatic` function to cast a null-pointer to a `SignalingClient` and call the non-static `protocolCallback`.

# Fix

I moved the entire `protocolCallback` logic into the static member function and removed the non-static member function.

# Context

I found this bug using `-fsanitize=address` and `-fsanitize=undefined`. This bug occurs on an _idle_ villas-node process, without any configuration or user input.

```console
$ ./build/src/villas-node
11:10:04 info node             This is VILLASnode v0.11.0-db2bd63-debug (built on Jan  1 1980, 00:00:00)
11:10:04 info signals          Initialize subsystem
11:10:04 warn node             No configuration file specified. Starting unconfigured. Use the API to configure this instance.
11:10:04 info memory           Initialize memory sub-system: #hugepages=100
11:10:04 warn memory:mmap      Running in an unprivileged environment. Hugepages are not used!
11:10:04 warn memory           Running in an unprivileged environment. Memory is not locked to RAM!
11:10:04 info kernel:rt        Initialize sub-system
11:10:04 warn kernel:rt        We recommend to use an PREEMPT_RT patched kernel!
11:10:04 warn kernel:rt        You might want to use the 'priority' setting to increase VILLASnode's process priority
11:10:04 warn kernel:rt        You might want to use the 'affinity' setting to pin VILLASnode to dedicate CPU cores
11:10:04 info api              Starting sub-system
11:10:04 info web              Starting sub-system
11:10:04 info api              Started worker
11:10:05 info web              Started worker
11:10:05 info stats             Node      │      Recv │      Sent │      Drop │      Skip │  OWD last │  OWD mean │ Rate last │ Rate mean │  Age mean │   Age Max │ Signals
11:10:05 info stats                       │      pkts │      pkts │      pkts │      pkts │      secs │      secs │   pkt/sec │   pkt/sec │      secs │       sec │ signals
11:10:05 info stats            ───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼─────────
/home/pjungkamp/Projects/VILLASframework/node/lib/nodes/webrtc/signaling_client.cpp:107:29: runtime error: member call on null pointer of type 'struct SignalingClient'
^C11:10:35 info node             Received Interrupt signal. Terminating...
11:10:35 info api              Stopping sub-system
11:10:35 info api              Stopped worker
11:10:35 info web              Stopping sub-system
11:10:35 info web              Stopped worker
11:10:35 info node             Goodbye!
```