### PR TITLE
Use "The VILLASframework Authors" as copyright owners in LICENSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(villas-node
 
 # Some more project settings
 set(PROJECT_AUTHOR "Steffen Vogel")
-set(PROJECT_COPYRIGHT "2014-2021, Institute for Automation of Complex Power Systems, RWTH Aachen University")
+set(PROJECT_COPYRIGHT "2014-2025 The VILLASframework Authors")
 
 # Several CMake settings/defaults
 set(CMAKE_C_STANDARD 11)

--- a/LICENSE
+++ b/LICENSE
@@ -58,7 +58,7 @@ APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2014-2025 The VILLASframework Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -58,7 +58,7 @@ APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2014-2025 The VILLASframework Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSES/BSD-1-Clause.txt
+++ b/LICENSES/BSD-1-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner>. All rights reserved.
+Copyright (c) 2014-2025 The VILLASframework Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner>
+Copyright (c) 2014-2025 The VILLASframework Authors
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University.
+Copyright (c) 2014-2025 The VILLASframework Authors.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,7 @@ We kindly ask all academic publications employing components of VILLASframework 
 
 For other licensing options please consult [Prof. Antonello Monti](mailto:amonti@eonerc.rwth-aachen.de).
 
-- SPDX-FileCopyrightText: 2014-2025 Institute for Automation of Complex Power Systems, RWTH Aachen University
-- SPDX-FileCopyrightText: 2023-2025 OPAL-RT Germany GmbH
-- SPDX-FileCopyrightText: 2022-2025 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
-- SPDX-FileCopyrightText: 2018-2025 Steffen Vogel <post@steffenvogel.de>
-- SPDX-FileCopyrightText: 2018 Daniel Krebs <dkrebs@eonerc.rwth-aachen.de>
+- SPDX-FileCopyrightText: 2014-2025 The VILLASframework Authors
 - SPDX-License-Identifier: Apache-2.0
 
 ## Contact
@@ -64,7 +60,7 @@ For other licensing options please consult [Prof. Antonello Monti](mailto:amonti
 [![EONERC ACS Logo](doc/pictures/eonerc_logo.png)](http://www.acs.eonerc.rwth-aachen.de)
 
 - Steffen Vogel <post@steffenvogel.de>
-- Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+- Niklas Eiling <niklas@eil.ing>
 - Felix Wege <fwege@eonerc.rwth-aachen.de>
 - Alexandra Bach <alexandra.bach@eonerc.rwth-aachen.de>
 

--- a/common/lib/tool.cpp
+++ b/common/lib/tool.cpp
@@ -21,9 +21,7 @@ void Tool::printCopyright() {
   std::cout << PROJECT_NAME " " << CLR_BLU(PROJECT_BUILD_ID)
             << " (built on " CLR_MAG(__DATE__) " " CLR_MAG(__TIME__) ")"
             << std::endl
-            << " Copyright 2014-2021, Institute for Automation of Complex "
-               "Power Systems, RWTH Aachen University"
-            << std::endl
+            << " Copyright 2014-2025 The VILLASframework Authors" << std::endl
             << " Steffen Vogel <post@steffenvogel.de>" << std::endl;
 }
 

--- a/web/webrtc.html
+++ b/web/webrtc.html
@@ -14,7 +14,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.27.0/themes/prism.css">
     <style>
         pre,
@@ -74,7 +75,7 @@
     </style>
 
     <script>
-        (function() {
+        (function () {
             var btnConnect = null;
             var btnDisconnect = null;
             var btnSend = null;
@@ -210,7 +211,7 @@
 
                 function fixLoggingFunc(name) {
                     console['old' + name] = console[name];
-                    console[name] = function(...arguments) {
+                    console[name] = function (...arguments) {
                         const output = produceOutput(name, arguments);
 
                         const isScrolledToBottom = logContainer.scrollHeight - logContainer.clientHeight <= logContainer.scrollTop + 1;
@@ -224,7 +225,7 @@
                     };
                 }
 
-                for (logger of['log', 'debug', 'warn', 'error', 'info']) {
+                for (logger of ['log', 'debug', 'warn', 'error', 'info']) {
                     fixLoggingFunc(logger);
                 }
             }
@@ -254,7 +255,8 @@
                             signal: 'random'
                         }
                     },
-                    paths: [{ in: ['siggen_1'],
+                    paths: [{
+                        in: ['siggen_1'],
                         out: ['webrtc_1']
                     }]
                 }
@@ -461,7 +463,9 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid">
             <a class="navbar-brand" href="#">
-                <img src="https://git.rwth-aachen.de/acs/public/villas/node/-/raw/master/doc/pictures/villas_node.svg" alt="VILLASnode logo" width="30" height="24" class="d-inline-block align-text-top"> VILLASnode: Simple WebRTC node example
+                <img src="https://git.rwth-aachen.de/acs/public/villas/node/-/raw/master/doc/pictures/villas_node.svg"
+                    alt="VILLASnode logo" width="30" height="24" class="d-inline-block align-text-top"> VILLASnode:
+                Simple WebRTC node example
             </a>
             <div class="btn-group" role="group" aria-label="Basic example">
                 <button class="btn btn-outline-success" id="connect">Connect</button>
@@ -502,7 +506,9 @@
             </div>
         </div>
 
-        <h3>VILLASnode setup <button class="btn-sm btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">Show</button></h3>
+        <h3>VILLASnode setup <button class="btn-sm btn-primary" type="button" data-bs-toggle="collapse"
+                data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">Show</button>
+        </h3>
         <div class="collapse" id="collapseExample">
             <div class="card card-body">
                 <h4>Config</h4>
@@ -513,12 +519,14 @@
                 </div>
 
                 <h4>Invocation</h4>
-                <p> Make sure <code>webrtc.conf</code> is in your current working directory and then run the following command:</p>
+                <p> Make sure <code>webrtc.conf</code> is in your current working directory and then run the following
+                    command:</p>
                 <pre><code>
 villas signal sine -r 5 | villas pipe webrtc.conf webrtc_1
 </code></pre>
                 <h5>With Docker</h5>
-                You can also start VILLASnode via <a href="https://docs.docker.com/get-docker/">Docker</a> by running the following command before the commands in the previous section.
+                You can also start VILLASnode via <a href="https://docs.docker.com/get-docker/">Docker</a> by running
+                the following command before the commands in the previous section.
                 <pre><code>
 alias villas='docker run -v $(pwd):/mount -w /mount registry.git.rwth-aachen.de/acs/public/villas/node'
 </code></pre>
@@ -542,13 +550,16 @@ alias villas='docker run -v $(pwd):/mount -w /mount registry.git.rwth-aachen.de/
         </div>
 
         <footer class="bg-light text-center text-lg-start fixed-bottom">
-            <div class="text-center p-3" style="background-color: rgba(var(--bs-light-rgb),var(--bs-bg-opacity))!important;">
-                © 2022 Copyright:
-                <a class="text-dark" href="https://www.acs.eonerc.rwth-aachen.de/">Institute for Automation of Complex Power Systems, RWTH Aachen University</a>
+            <div class="text-center p-3"
+                style="background-color: rgba(var(--bs-light-rgb),var(--bs-bg-opacity))!important;">
+                © 2014-2025 Copyright:
+                <a class="text-dark" href="https://www.acs.eonerc.rwth-aachen.de/">The VILLASframework Authors</a>
             </div>
         </footer>
 
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/prismjs@1.27.0/prism.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/prismjs@1.27.0/plugins/autoloader/prism-autoloader.min.js"></script>
 </body>


### PR DESCRIPTION
Let's continue the discussion from #939 here.

Pro:
  - Have a copyright owner in the LICENSE file
  - It is broad enough to include everybody
  - This is recommended by the [Linux Foundation](https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects)
  - Was requested by one of the JOSS Reviewers
 
Con:
  - Generic LICENSE files are acceptable according to SPDX (I think?), so this may be a change without a need
  - We have to update the copyright year every year.
  - Inconsistent with copyright notices in files (although it is not contradicting those)

In the future we could also use "The VILLASframework Authors" in files missing more explicit copyright notices.

