### PR TITLE
fix(compat): Add drop-in std::filesystem header for older systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,19 +76,16 @@ find_package(Lua)
 find_package(LibDataChannel)
 find_package(re)
 find_package(OpenDSSC)
+find_package(FileSystem)
 
 # Check for tools
+find_program(PROTOBUFC_COMPILER NAMES protoc-c)
+find_program(PROTOBUF_COMPILER NAMES protoc)
 find_program(PASTE NAMES paste)
 if(NOT PASTE)
     message(SEND_ERROR "GNU paste is missing. Please install coreutils")
 endif()
 
-# Check programs
-find_program(PROTOBUFC_COMPILER NAMES protoc-c)
-find_program(PROTOBUF_COMPILER NAMES protoc)
-
-# Build without any GPL-code
-option(WITHOUT_GPL "Build VILLASnode without any GPL code" OFF)
 
 set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig:/usr/lib64/pkgconfig")
 
@@ -157,7 +154,15 @@ else()
     set(FOUND_FPGA_SUBMODULES OFF)
 endif()
 
+if(CXX17_FILESYSTEM)
+    set(STDCXX_FS_NOT_FOUND OFF)
+else()
+    set(STDCXX_FS_NOT_FOUND ON)
+endif()
+
 # Build options
+cmake_dependent_option(WITHOUT_GPL          "Build VILLASnode without any GPL code"                 OFF                "" ON)
+cmake_dependent_option(WITH_GHC_FS          "Build using ghc::filesystem, a drop in replacement for std::filesystem"  ON "STDCXX_FS_NOT_FOUND" OFF)
 cmake_dependent_option(WITH_DEFAULTS        "Defaults for non required build options"               ON                 "" OFF)
 
 cmake_dependent_option(WITH_API             "Build with remote control API"                         "${WITH_DEFAULTS}" "" OFF)
@@ -206,7 +211,7 @@ cmake_dependent_option(WITH_NODE_WEBSOCKET  "Build with websocket node-type"    
 cmake_dependent_option(WITH_NODE_ZEROMQ     "Build with zeromq node-type"                           "${WITH_DEFAULTS}" "LIBZMQ_FOUND; NOT WITHOUT_GPL" OFF)
 cmake_dependent_option(WITH_NODE_OPENDSS    "Build with opendss node-type"                          "${WITH_DEFAULTS}" "OpenDSSC_FOUND" OFF)
 
-# set a default for the build type
+# Set a default for the build type
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
@@ -225,6 +230,11 @@ if(VILLAS_COMPILE_WARNING_AS_ERROR)
     add_compile_options(-Werror)
 else()
     add_compile_options(-Wno-error)
+endif()
+
+if(WITH_GHC_FS)
+    find_package(ghc_filesystem 1.5.14 REQUIRED)
+    include_directories($<TARGET_PROPERTY:ghcFilesystem::ghc_filesystem,INTERFACE_INCLUDE_DIRECTORIES>)
 endif()
 
 # Get version info and buildid from Git

--- a/cmake/FindFileSystem.cmake
+++ b/cmake/FindFileSystem.cmake
@@ -1,0 +1,22 @@
+# CMakeLists.txt.
+#
+# Author: Steffen Vogel <post@steffenvogel.de>
+# SPDX-FileCopyrightText: 2025 Steffen Vogel <steffen.vogel@opal-rt.com>
+# SPDX-License-Identifier: Apache-2.0
+
+set(FILESYSTEM_TEST_CODE "
+#include <filesystem>
+
+int main(void) {
+	return std::filesystem::is_regular_file(\"/\") ? 0 : 1;
+}
+")
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+cmake_push_check_state(RESET)
+check_cxx_source_compiles("${FILESYSTEM_TEST_CODE}" CXX17_FILESYSTEM)
+cmake_pop_check_state()
+
+unset(FILESYSTEM_TEST_CODE)

--- a/common/include/villas/config.hpp.in
+++ b/common/include/villas/config.hpp.in
@@ -53,5 +53,6 @@
 
 // Library features
 #cmakedefine FMT_LEGACY_OSTREAM_FORMATTER
+#cmakedefine WITH_GHC_FS
 
 // clang-format on

--- a/common/include/villas/fs.hpp
+++ b/common/include/villas/fs.hpp
@@ -1,0 +1,16 @@
+/* std::filesystem compatibility wrapper
+ *
+ * Author: Steffen Vogel <steffen.vogel@opal-rt.com>
+ * SPDX-FileCopyrightText: 2025, OPAL-RT Germany GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <villas/config.hpp>
+
+#ifdef WITH_GHC_FS
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif

--- a/common/include/villas/kernel/devices/device.hpp
+++ b/common/include/villas/kernel/devices/device.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <filesystem>
 #include <optional>
 
+#include <villas/fs.hpp>
 #include <villas/kernel/devices/driver.hpp>
 
 namespace villas {
@@ -24,8 +24,8 @@ public:
   virtual std::optional<std::unique_ptr<Driver>> driver() const = 0;
   virtual std::optional<int> iommu_group() const = 0;
   virtual std::string name() const = 0;
-  virtual std::filesystem::path override_path() const = 0;
-  virtual std::filesystem::path path() const = 0;
+  virtual fs::path override_path() const = 0;
+  virtual fs::path path() const = 0;
   virtual void probe() const = 0;
 };
 

--- a/common/include/villas/kernel/devices/ip_device.hpp
+++ b/common/include/villas/kernel/devices/ip_device.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <filesystem>
 #include <vector>
 
+#include <villas/fs.hpp>
 #include <villas/kernel/devices/platform_device.hpp>
 
 namespace villas {
@@ -19,21 +19,20 @@ namespace devices {
 
 class IpDevice : public PlatformDevice {
 public:
-  static IpDevice from(const std::filesystem::path unsafe_path);
-  static bool is_path_valid(const std::filesystem::path unsafe_path);
+  static IpDevice from(const fs::path unsafe_path);
+  static bool is_path_valid(const fs::path unsafe_path);
 
 private:
   IpDevice() = delete;
-  IpDevice(
-      const std::filesystem::path valid_path) //! Dont allow unvalidated paths
-      : PlatformDevice(valid_path){};
+  IpDevice(const fs::path valid_path) //! Dont allow unvalidated paths
+      : PlatformDevice(valid_path) {};
 
 public:
   size_t addr() const;
   std::string ip_name() const;
 
   static std::vector<villas::kernel::devices::IpDevice>
-  from_directory(std::filesystem::path devices_directory);
+  from_directory(fs::path devices_directory);
 };
 
 } // namespace devices

--- a/common/include/villas/kernel/devices/ip_device.hpp
+++ b/common/include/villas/kernel/devices/ip_device.hpp
@@ -25,7 +25,7 @@ public:
 private:
   IpDevice() = delete;
   IpDevice(const fs::path valid_path) //! Dont allow unvalidated paths
-      : PlatformDevice(valid_path) {};
+      : PlatformDevice(valid_path){};
 
 public:
   size_t addr() const;

--- a/common/include/villas/kernel/devices/linux_driver.hpp
+++ b/common/include/villas/kernel/devices/linux_driver.hpp
@@ -33,11 +33,11 @@ private:
 public:
   LinuxDriver(const fs::path path)
       : LinuxDriver(path, path / fs::path(BIND_DEFAULT),
-                    path / fs::path(UNBIND_DEFAULT)) {};
+                    path / fs::path(UNBIND_DEFAULT)){};
 
   LinuxDriver(const fs::path path, const fs::path bind_path,
               const fs::path unbind_path)
-      : path(path), bind_path(bind_path), unbind_path(unbind_path) {};
+      : path(path), bind_path(bind_path), unbind_path(unbind_path){};
 
 public:
   void attach(const Device &device) const override;

--- a/common/include/villas/kernel/devices/linux_driver.hpp
+++ b/common/include/villas/kernel/devices/linux_driver.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 
+#include <villas/fs.hpp>
 #include <villas/kernel/devices/driver.hpp>
 
 namespace villas {
@@ -24,21 +24,20 @@ private:
   static constexpr char UNBIND_DEFAULT[] = "unbind";
 
 public:
-  const std::filesystem::path path;
+  const fs::path path;
 
 private:
-  const std::filesystem::path bind_path;
-  const std::filesystem::path unbind_path;
+  const fs::path bind_path;
+  const fs::path unbind_path;
 
 public:
-  LinuxDriver(const std::filesystem::path path)
-      : LinuxDriver(path, path / std::filesystem::path(BIND_DEFAULT),
-                    path / std::filesystem::path(UNBIND_DEFAULT)){};
+  LinuxDriver(const fs::path path)
+      : LinuxDriver(path, path / fs::path(BIND_DEFAULT),
+                    path / fs::path(UNBIND_DEFAULT)) {};
 
-  LinuxDriver(const std::filesystem::path path,
-              const std::filesystem::path bind_path,
-              const std::filesystem::path unbind_path)
-      : path(path), bind_path(bind_path), unbind_path(unbind_path){};
+  LinuxDriver(const fs::path path, const fs::path bind_path,
+              const fs::path unbind_path)
+      : path(path), bind_path(bind_path), unbind_path(unbind_path) {};
 
 public:
   void attach(const Device &device) const override;

--- a/common/include/villas/kernel/devices/platform_device.hpp
+++ b/common/include/villas/kernel/devices/platform_device.hpp
@@ -29,7 +29,7 @@ private:
 public:
   PlatformDevice(const fs::path path)
       : PlatformDevice(path, fs::path(PROBE_DEFAULT),
-                       path / fs::path(OVERRIDE_DEFAULT)) {};
+                       path / fs::path(OVERRIDE_DEFAULT)){};
 
   PlatformDevice(const fs::path path, const fs::path probe_path,
                  const fs::path override_path)

--- a/common/include/villas/kernel/devices/platform_device.hpp
+++ b/common/include/villas/kernel/devices/platform_device.hpp
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include <filesystem>
-
+#include <villas/fs.hpp>
 #include <villas/kernel/devices/device.hpp>
 #include <villas/kernel/devices/driver.hpp>
 
@@ -23,18 +22,17 @@ private:
   static constexpr char OVERRIDE_DEFAULT[] = "driver_override";
 
 private:
-  const std::filesystem::path m_path;
-  const std::filesystem::path m_probe_path;
-  const std::filesystem::path m_override_path;
+  const fs::path m_path;
+  const fs::path m_probe_path;
+  const fs::path m_override_path;
 
 public:
-  PlatformDevice(const std::filesystem::path path)
-      : PlatformDevice(path, std::filesystem::path(PROBE_DEFAULT),
-                       path / std::filesystem::path(OVERRIDE_DEFAULT)){};
+  PlatformDevice(const fs::path path)
+      : PlatformDevice(path, fs::path(PROBE_DEFAULT),
+                       path / fs::path(OVERRIDE_DEFAULT)) {};
 
-  PlatformDevice(const std::filesystem::path path,
-                 const std::filesystem::path probe_path,
-                 const std::filesystem::path override_path)
+  PlatformDevice(const fs::path path, const fs::path probe_path,
+                 const fs::path override_path)
       : m_path(path), m_probe_path(probe_path),
         m_override_path(override_path){};
 
@@ -42,8 +40,8 @@ public:
   std::optional<std::unique_ptr<Driver>> driver() const override;
   std::optional<int> iommu_group() const override;
   std::string name() const override;
-  std::filesystem::path override_path() const override;
-  std::filesystem::path path() const override;
+  fs::path override_path() const override;
+  fs::path path() const override;
   void probe() const override;
 };
 

--- a/common/include/villas/utils.hpp
+++ b/common/include/villas/utils.hpp
@@ -11,7 +11,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
-#include <filesystem>
 #include <list>
 #include <string>
 #include <vector>
@@ -22,6 +21,7 @@
 #include <sys/types.h>
 
 #include <villas/config.hpp>
+#include <villas/fs.hpp>
 
 #ifdef __GNUC__
 #define LIKELY(x) __builtin_expect((x), 1)
@@ -212,9 +212,8 @@ template <class... Ts> struct overloaded : Ts... {
 // Explicit deduction guide (not needed as of C++20)
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
-void write_to_file(std::string data, const std::filesystem::path file);
-std::vector<std::string>
-read_names_in_directory(const std::filesystem::path &directory);
+void write_to_file(std::string data, const fs::path file);
+std::vector<std::string> read_names_in_directory(const fs::path &directory);
 
 namespace base64 {
 

--- a/common/lib/kernel/devices/device_connection.cpp
+++ b/common/lib/kernel/devices/device_connection.cpp
@@ -26,8 +26,7 @@ DeviceConnection DeviceConnection::from(
   auto logger = villas::Log::get("Builder: DeviceConnection");
 
   // Bind the devicetree device to vfio driver
-  LinuxDriver driver(
-      std::filesystem::path("/sys/bus/platform/drivers/vfio-platform"));
+  LinuxDriver driver(fs::path("/sys/bus/platform/drivers/vfio-platform"));
   driver.attach(device);
 
   // Attach vfio container to the iommu group

--- a/common/lib/kernel/devices/ip_device.cpp
+++ b/common/lib/kernel/devices/ip_device.cpp
@@ -6,17 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <filesystem>
 #include <regex>
 #include <stdexcept>
 
 #include <villas/exceptions.hpp>
+#include <villas/fs.hpp>
 #include <villas/kernel/devices/ip_device.hpp>
 #include <villas/utils.hpp>
 
 using villas::kernel::devices::IpDevice;
 
-IpDevice IpDevice::from(const std::filesystem::path unsafe_path) {
+IpDevice IpDevice::from(const fs::path unsafe_path) {
   if (!is_path_valid(unsafe_path))
     throw RuntimeError(
         "Path {} failed validation as IpDevicePath [adress in hex].[name] ",
@@ -42,7 +42,7 @@ size_t IpDevice::addr() const {
   return addr;
 }
 
-bool IpDevice::is_path_valid(const std::filesystem::path unsafe_path) {
+bool IpDevice::is_path_valid(const fs::path unsafe_path) {
   std::string assumed_device_name = unsafe_path.filename();
 
   // Match format of hexaddr.devicename
@@ -55,15 +55,14 @@ bool IpDevice::is_path_valid(const std::filesystem::path unsafe_path) {
 }
 
 std::vector<villas::kernel::devices::IpDevice>
-IpDevice::from_directory(std::filesystem::path devices_directory) {
+IpDevice::from_directory(fs::path devices_directory) {
   std::vector<villas::kernel::devices::IpDevice> devices;
 
   const std::vector<std::string> devicetree_names =
       villas::utils::read_names_in_directory(devices_directory);
 
   for (auto devicetree_name : devicetree_names) {
-    auto path_to_device =
-        devices_directory / std::filesystem::path(devicetree_name);
+    auto path_to_device = devices_directory / fs::path(devicetree_name);
     try {
       auto device = villas::kernel::devices::IpDevice::from(path_to_device);
       devices.push_back(device);

--- a/common/lib/kernel/devices/platform_device.cpp
+++ b/common/lib/kernel/devices/platform_device.cpp
@@ -15,36 +15,31 @@ using villas::kernel::devices::PlatformDevice;
 using villas::utils::write_to_file;
 
 std::optional<std::unique_ptr<Driver>> PlatformDevice::driver() const {
-  std::filesystem::path driver_symlink =
-      this->m_path / std::filesystem::path("driver");
+  fs::path driver_symlink = this->m_path / fs::path("driver");
 
-  if (!std::filesystem::is_symlink(driver_symlink))
+  if (!fs::is_symlink(driver_symlink))
     return std::nullopt;
 
-  std::filesystem::path driver_path =
-      std::filesystem::canonical(driver_symlink);
+  fs::path driver_path = fs::canonical(driver_symlink);
   return std::make_optional(std::make_unique<LinuxDriver>(driver_path));
 }
 
 std::optional<int> PlatformDevice::iommu_group() const {
-  std::filesystem::path symlink =
-      std::filesystem::path(this->m_path.u8string() + "/iommu_group");
+  fs::path symlink = fs::path(this->m_path.u8string() + "/iommu_group");
 
-  std::filesystem::path link = std::filesystem::read_symlink(symlink);
+  fs::path link = fs::read_symlink(symlink);
   std::string delimiter = "iommu_groups/";
   int pos = link.u8string().find(delimiter);
   int iommu_group = std::stoi(link.u8string().substr(pos + delimiter.length()));
   return std::make_optional<int>(iommu_group);
 }
 
-std::filesystem::path PlatformDevice::path() const { return this->m_path; };
+fs::path PlatformDevice::path() const { return this->m_path; };
 
 void PlatformDevice::probe() const {
   write_to_file(this->name(), this->m_probe_path);
 }
 
-std::filesystem::path PlatformDevice::override_path() const {
-  return this->m_override_path;
-}
+fs::path PlatformDevice::override_path() const { return this->m_override_path; }
 
 std::string PlatformDevice::name() const { return this->m_path.filename(); }

--- a/common/lib/utils.cpp
+++ b/common/lib/utils.cpp
@@ -13,7 +13,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -31,6 +30,7 @@
 #include <villas/colors.hpp>
 #include <villas/config.hpp>
 #include <villas/exceptions.hpp>
+#include <villas/fs.hpp>
 #include <villas/log.hpp>
 #include <villas/utils.hpp>
 
@@ -354,7 +354,7 @@ bool isPrivileged() {
   return true;
 }
 
-void write_to_file(std::string data, const std::filesystem::path file) {
+void write_to_file(std::string data, const fs::path file) {
   villas::Log::get("Filewriter")->debug("{} > {}", data, file.u8string());
   std::ofstream outputFile(file.u8string());
 
@@ -362,15 +362,13 @@ void write_to_file(std::string data, const std::filesystem::path file) {
     outputFile << data;
     outputFile.close();
   } else {
-    throw std::filesystem::filesystem_error("Cannot open outputfile",
-                                            std::error_code());
+    throw fs::filesystem_error("Cannot open outputfile", std::error_code());
   }
 }
 
-std::vector<std::string>
-read_names_in_directory(const std::filesystem::path &directory) {
+std::vector<std::string> read_names_in_directory(const fs::path &directory) {
   std::vector<std::string> names;
-  for (auto const &dir_entry : std::filesystem::directory_iterator{directory}) {
+  for (auto const &dir_entry : fs::directory_iterator{directory}) {
     names.push_back(dir_entry.path().filename());
   }
   return names;

--- a/fpga/include/villas/fpga/card.hpp
+++ b/fpga/include/villas/fpga/card.hpp
@@ -10,10 +10,10 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string>
 
 #include <villas/fpga/core.hpp>
+#include <villas/fs.hpp>
 #include <villas/kernel/vfio_container.hpp>
 
 namespace villas {
@@ -61,7 +61,7 @@ private:
 
 public:
   static void loadIps(std::shared_ptr<Card> card, json_t *json_ips,
-                      const std::filesystem::path &searchPath);
+                      const fs::path &searchPath);
   static void loadSwitch(std::shared_ptr<Card> card, json_t *json_paths);
 };
 

--- a/fpga/include/villas/fpga/pcie_card.hpp
+++ b/fpga/include/villas/fpga/pcie_card.hpp
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <filesystem>
 #include <list>
 #include <set>
 #include <string>
@@ -20,6 +19,7 @@
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/config.h>
 #include <villas/fpga/core.hpp>
+#include <villas/fs.hpp>
 #include <villas/kernel/devices/pci_device.hpp>
 #include <villas/kernel/vfio_container.hpp>
 #include <villas/memory.hpp>
@@ -64,8 +64,7 @@ class PCIeCardFactory : public plugin::Plugin {
 public:
   static std::shared_ptr<PCIeCard>
   make(json_t *json, std::string card_name,
-       std::shared_ptr<kernel::vfio::Container> vc,
-       const std::filesystem::path &searchPath);
+       std::shared_ptr<kernel::vfio::Container> vc, const fs::path &searchPath);
 
   static PCIeCard *make() { return new PCIeCard(); }
 

--- a/fpga/include/villas/fpga/platform_card.hpp
+++ b/fpga/include/villas/fpga/platform_card.hpp
@@ -12,11 +12,11 @@
 
 #pragma once
 
-#include <filesystem>
 #include <vector>
 
 #include <villas/fpga/card.hpp>
 #include <villas/fpga/core_connection.hpp>
+#include <villas/fs.hpp>
 
 namespace villas {
 namespace fpga {
@@ -38,8 +38,7 @@ class PlatformCardFactory {
 public:
   static std::shared_ptr<PlatformCard>
   make(json_t *json_card, std::string card_name,
-       std::shared_ptr<kernel::vfio::Container> vc,
-       const std::filesystem::path &searchPath);
+       std::shared_ptr<kernel::vfio::Container> vc, const fs::path &searchPath);
 };
 
 } /* namespace fpga */

--- a/fpga/include/villas/fpga/utils.hpp
+++ b/fpga/include/villas/fpga/utils.hpp
@@ -19,13 +19,13 @@ std::shared_ptr<fpga::Card> setupFpgaCard(const std::string &configFile,
                                           const std::string &fpgaName);
 
 std::shared_ptr<fpga::Card>
-createCard(json_t *config, const std::filesystem::path &searchPath,
+createCard(json_t *config, const fs::path &searchPath,
            std::shared_ptr<kernel::vfio::Container> vfioContainer,
            std::string card_name = "anonymous Card");
 
 int createCards(
     json_t *config, std::list<std::shared_ptr<fpga::Card>> &cards,
-    const std::filesystem::path &searchPath,
+    const fs::path &searchPath,
     std::shared_ptr<kernel::vfio::Container> vfioContainer = nullptr);
 int createCards(
     json_t *config, std::list<std::shared_ptr<fpga::Card>> &cards,

--- a/fpga/lib/card.cpp
+++ b/fpga/lib/card.cpp
@@ -129,7 +129,7 @@ bool Card::mapMemoryBlock(const std::shared_ptr<MemoryBlock> block) {
 }
 
 void CardFactory::loadIps(std::shared_ptr<Card> card, json_t *json_ips,
-                          const std::filesystem::path &searchPath) {
+                          const fs::path &searchPath) {
   auto logger = getStaticLogger();
 
   // Load IPs from a separate json file
@@ -140,8 +140,7 @@ void CardFactory::loadIps(std::shared_ptr<Card> card, json_t *json_ips,
   }
 
   if (!searchPath.empty()) {
-    std::filesystem::path json_ips_path =
-        searchPath / json_string_value(json_ips);
+    fs::path json_ips_path = searchPath / json_string_value(json_ips);
     logger->debug("searching for FPGA IP cors config at {}",
                   json_ips_path.string());
     json_ips = json_load_file(json_ips_path.c_str(), 0, nullptr);

--- a/fpga/lib/core_connection.cpp
+++ b/fpga/lib/core_connection.cpp
@@ -26,8 +26,7 @@ CoreConnection
 CoreConnection::from(std::shared_ptr<villas::fpga::ip::Core> ip,
                      std::shared_ptr<kernel::vfio::Container> vfio_container) {
   // Find matching OS device for ip
-  const std::filesystem::path PLATFORM_DEVICES_DIRECTORY(
-      "/sys/bus/platform/devices");
+  const fs::path PLATFORM_DEVICES_DIRECTORY("/sys/bus/platform/devices");
   std::vector<villas::kernel::devices::IpDevice> devices =
       villas::kernel::devices::IpDevice::from_directory(
           PLATFORM_DEVICES_DIRECTORY);

--- a/fpga/lib/pcie_card.cpp
+++ b/fpga/lib/pcie_card.cpp
@@ -31,7 +31,7 @@ static const kernel::devices::PciDevice defaultFilter(
 std::shared_ptr<PCIeCard>
 PCIeCardFactory::make(json_t *json_card, std::string card_name,
                       std::shared_ptr<kernel::vfio::Container> vc,
-                      const std::filesystem::path &searchPath) {
+                      const fs::path &searchPath) {
   auto logger = getStaticLogger();
 
   // make sure the vfio container has the required modules

--- a/fpga/lib/platform_card.cpp
+++ b/fpga/lib/platform_card.cpp
@@ -88,7 +88,7 @@ bool PlatformCard::mapMemoryBlock(const std::shared_ptr<MemoryBlock> block) {
 std::shared_ptr<PlatformCard>
 PlatformCardFactory::make(json_t *json_card, std::string card_name,
                           std::shared_ptr<kernel::vfio::Container> vc,
-                          const std::filesystem::path &searchPath) {
+                          const fs::path &searchPath) {
   auto logger = villas::Log::get("PlatformCardFactory");
 
   // make sure the vfio container has the required modules

--- a/fpga/lib/utils.cpp
+++ b/fpga/lib/utils.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <csignal>
-#include <filesystem>
 #include <iostream>
 #include <regex>
 #include <string>
@@ -26,6 +25,7 @@
 #include <villas/fpga/platform_card.hpp>
 #include <villas/fpga/utils.hpp>
 #include <villas/fpga/vlnv.hpp>
+#include <villas/fs.hpp>
 #include <villas/log.hpp>
 #include <villas/utils.hpp>
 
@@ -232,10 +232,10 @@ void fpga::setupColorHandling() {
 }
 
 std::shared_ptr<fpga::Card>
-fpga::createCard(json_t *config, const std::filesystem::path &searchPath,
+fpga::createCard(json_t *config, const fs::path &searchPath,
                  std::shared_ptr<kernel::vfio::Container> vfioContainer,
                  std::string card_name) {
-  auto configDir = std::filesystem::path().parent_path();
+  auto configDir = fs::path().parent_path();
 
   const char *interfaceName;
   json_error_t err;
@@ -263,13 +263,13 @@ fpga::createCard(json_t *config, const std::filesystem::path &searchPath,
 
 int fpga::createCards(json_t *config,
                       std::list<std::shared_ptr<fpga::Card>> &cards,
-                      const std::filesystem::path &searchPath,
+                      const fs::path &searchPath,
                       std::shared_ptr<kernel::vfio::Container> vfioContainer) {
   int numFpgas = 0;
   if (vfioContainer == nullptr) {
     vfioContainer = std::make_shared<kernel::vfio::Container>();
   }
-  auto configDir = std::filesystem::path().parent_path();
+  auto configDir = fs::path().parent_path();
 
   json_t *fpgas = json_object_get(config, "fpgas");
   if (fpgas == nullptr) {
@@ -294,13 +294,13 @@ int fpga::createCards(json_t *config,
                       std::list<std::shared_ptr<fpga::Card>> &cards,
                       const std::string &searchPath,
                       std::shared_ptr<kernel::vfio::Container> vfioContainer) {
-  const auto fsPath = std::filesystem::path(searchPath);
+  const auto fsPath = fs::path(searchPath);
   return createCards(config, cards, fsPath, vfioContainer);
 }
 
 std::shared_ptr<fpga::Card> fpga::setupFpgaCard(const std::string &configFile,
                                                 const std::string &fpgaName) {
-  auto configDir = std::filesystem::path(configFile).parent_path();
+  auto configDir = fs::path(configFile).parent_path();
 
   // Parse FPGA configuration
   FILE *f = fopen(configFile.c_str(), "r");

--- a/fpga/tests/unit/fpga.cpp
+++ b/fpga/tests/unit/fpga.cpp
@@ -63,7 +63,7 @@ static void init() {
   cr_assert_not_null(fpgaCardFactory, "No plugin for FPGA card found");
 
   // Create all FPGA card instances using the corresponding plugin
-  auto configDir = std::filesystem::path(fn).parent_path();
+  auto configDir = fs::path(fn).parent_path();
   auto cards = std::list<std::shared_ptr<fpga::Card>>();
   fpga::createCards(json, cards, configDir);
   state.cards = cards;

--- a/include/villas/config_class.hpp
+++ b/include/villas/config_class.hpp
@@ -8,13 +8,13 @@
 #pragma once
 
 #include <cstdio>
-#include <filesystem>
 #include <functional>
 #include <regex>
 
 #include <jansson.h>
 #include <unistd.h>
 
+#include <villas/fs.hpp>
 #include <villas/log.hpp>
 #include <villas/node/config.hpp>
 

--- a/packaging/deps.sh
+++ b/packaging/deps.sh
@@ -489,6 +489,7 @@ if ! pkg-config "libmodbus >= 3.1.0" && \
     popd
 fi
 
+# Build & Install OpenDSS
 if ! find /usr/{local/,}{lib,bin} -name "libOpenDSSC.so" | grep -q . &&
     should_build "opendss" "For opendss node-type"; then
     git svn clone -r 4020:4020 https://svn.code.sf.net/p/electricdss/code/trunk/VersionC OpenDSS-C
@@ -505,6 +506,19 @@ if ! find /usr/{local/,}{lib,bin} -name "libOpenDSSC.so" | grep -q . &&
     fi
     cmake -DMyOutputType=DLL \
           ${OPENDSS_CMAKE_OPTS} \
+          ${CMAKE_OPTS} ..
+    make ${MAKE_OPTS} install
+    popd
+fi
+
+# Build & Install ghc::filesystem
+if ! cmake --find-package -DNAME=ghc_filesystem -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST >/dev/null 2>/dev/null && \
+    should_build "ghc_filesystem" "for compatability with older compilers"; then
+    git clone ${GIT_OPTS} --branch v1.5.14 https://github.com/gulrak/filesystem.git
+    mkdir -p filesystem/build
+    pushd filesystem/build
+    cmake -DGHC_FILESYSTEM_BUILD_TESTING=OFF \
+          -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF \
           ${CMAKE_OPTS} ..
     make ${MAKE_OPTS} install
     popd


### PR DESCRIPTION
Needed for some older compilers which do not include std::filesystem by default.