### PR TITLE
pre-commit: Add DCO check

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 use flake
+pre-commit install
+pre-commit install -t prepare-commit-msg

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,11 @@ repos:
       - id: markdownlint
         exclude: ^paper\.md$
         args: [-r, "~MD013,~MD033,~MD024"]
+
+  - repo: local
+    hooks:
+      - id: dco-hook
+        name: check DCO
+        entry: ./tools/pre-commit-dco-hook.sh
+        language: script
+        stages: [prepare-commit-msg]

--- a/tools/pre-commit-dco-hook.sh
+++ b/tools/pre-commit-dco-hook.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Append a Signed-off-by line to all git commit messages
+#
+# Author: Philipp Jungkamp <philipp.jungkamp@rwth-aachen.de>
+# SPDX-FileCopyrightText: 2014-2025 Institute for Automation of Complex Power Systems, RWTH Aachen University
+# SPDX-License-Identifier: Apache-2.0
+
+MESSAGE_FILE="$1"
+GIT_AUTHOR="$(git var GIT_AUTHOR_IDENT | sed -n 's|^\(.*>\).*$|\1|p')"
+SIGNOFF="Signed-off-by: $GIT_AUTHOR"
+
+if ! grep --quiet --fixed-strings --line-regexp "$SIGNOFF" "$MESSAGE_FILE" ; then
+  printf "\n%s" "$SIGNOFF" >> "$MESSAGE_FILE"
+fi
+
+exit 0


### PR DESCRIPTION
I found myself force-pushing some commits in **every** PR I've made, just to reword and signoff on all commits. I wrote a little prepare-commit-msg hook that appends the DCO to every commit message automatically.

---

You can install this hook using:

```shell
pre-commit install -t prepare-commit-msg
```