### PR TITLE
Add new Delta Sharing node-type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(villas-node
 
 # Some more project settings
 set(PROJECT_AUTHOR "Steffen Vogel")
-set(PROJECT_COPYRIGHT "2014-2021, Institute for Automation of Complex Power Systems, RWTH Aachen University")
+set(PROJECT_COPYRIGHT "2014-2025 The VILLASframework Authors")
 
 # Several CMake settings/defaults
 set(CMAKE_C_STANDARD 11)

--- a/include/villas/nodes/delta_sharing/Protocol.h
+++ b/include/villas/nodes/delta_sharing/Protocol.h
@@ -1,8 +1,14 @@
-#ifndef __PROTOCOL_H__
-#define __PROTOCOL_H__
+/* Node type: Delta Share.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
 
 #include <iostream>
-#include "jansson_wrapper.h"
+#include <villas/nodes/delta_sharing/jansson_wrapper.h>
 #include <map>
 #include <string>
 #include <vector>
@@ -135,8 +141,6 @@ namespace DeltaSharing
                 {
                     for (auto it = arr.begin(); it != arr.end(); ++it)
                     {
-                        // For jansson, we need to handle the array differently
-                        // This assumes partitionValues is an array of objects with key-value pairs
                         json item = *it;
                         if (item.is_object()) {
                             for (auto kv_it = item.begin(); kv_it != item.end(); ++kv_it) {
@@ -292,5 +296,3 @@ namespace DeltaSharing
 
     };
 };
-
-#endif

--- a/include/villas/nodes/delta_sharing/delta_sharing.hpp
+++ b/include/villas/nodes/delta_sharing/delta_sharing.hpp
@@ -1,6 +1,6 @@
-/* Node type: Delta Share.
+/* Node type: Delta Sharing.
  *
- * Author:
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
  * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,7 @@
 #include <jansson.h>
 
 #include <villas/nodes/delta_sharing/Protocol.h>
-#include <villas/nodes/delta_sharing/DeltaSharingClient.h>
+#include <villas/nodes/delta_sharing/delta_sharing_client.h>
 
 namespace arrow { class Table; }
 

--- a/include/villas/nodes/delta_sharing/delta_sharing_client.h
+++ b/include/villas/nodes/delta_sharing/delta_sharing_client.h
@@ -1,15 +1,20 @@
+/* Node type: Delta Share.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-#ifndef __DELTASHARINGCLIENT_H__
-#define __DELTASHARINGCLIENT_H__
+#pragma once
 
 #include <iostream>
-#include "DeltaSharingRestClient.h"
+#include <villas/nodes/delta_sharing/delta_sharing_rest_client.h>
 #include <arrow/table.h>
 
 namespace DeltaSharing
 {
-    
-    struct DeltaSharingClient 
+
+    struct DeltaSharingClient
     {
     public:
         DeltaSharingClient(std::string filename, boost::optional<std::string> cacheLocation);
@@ -30,5 +35,3 @@ namespace DeltaSharing
         int maxThreads;
     };
 };
-
-#endif

--- a/include/villas/nodes/delta_sharing/delta_sharing_rest_client.h
+++ b/include/villas/nodes/delta_sharing/delta_sharing_rest_client.h
@@ -1,16 +1,19 @@
+/* Node type: Delta Share.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-#ifndef __DELTASHARINGRESTCLIENT_H__
-#define __DELTASHARINGRESTCLIENT_H__
+#pragma once
 
 #include <iostream>
-// #include <nlohmann/json.hpp>
-#include "jansson_wrapper.h"
+#include <villas/nodes/delta_sharing/jansson_wrapper.h>
 #include <list>
-#include "Protocol.h"
+#include <villas/nodes/delta_sharing/Protocol.h>
 #include <restclient-cpp/restclient.h>
 #include <restclient-cpp/connection.h>
 
-// using json = DeltaSharing::JanssonWrapper::json;
 
 namespace DeltaSharing
 {
@@ -39,5 +42,3 @@ namespace DeltaSharing
         static const std::string user_agent;
     };
 };
-
-#endif

--- a/include/villas/nodes/delta_sharing/functions.h
+++ b/include/villas/nodes/delta_sharing/functions.h
@@ -1,22 +1,27 @@
+/* Node type: Delta Share.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-#ifndef __FUNCTIONS_H__
-#define __FUNCTIONS_H__
+#pragma once
 
 #include <vector>
 #include <string>
 #include <iostream>
 #include <arrow/table.h>
-#include "DeltaSharingClient.h"
+#include <villas/nodes/delta_sharing/delta_sharing_client.h>
 #include <thread>
 
 namespace DeltaSharing {
 
-    const std::vector<std::string> ParseURL(std::string path); 
-     std::shared_ptr<DeltaSharingClient> NewDeltaSharingClient(std::string profile, boost::optional<std::string> cacheLocation);
-    const std::shared_ptr<arrow::Table> LoadAsArrowTable(std::string path, int fileno);
-
-   
-   
+const std::vector<std::string> ParseURL(std::string path);
+std::shared_ptr<DeltaSharingClient>
+NewDeltaSharingClient(std::string profile,
+                      boost::optional<std::string> cacheLocation);
+const std::shared_ptr<arrow::Table> LoadAsArrowTable(std::string path,
+                                                     int fileno);
 };
 
-#endif
+// namespace DeltaSharing

--- a/include/villas/nodes/delta_sharing/jansson_wrapper.h
+++ b/include/villas/nodes/delta_sharing/jansson_wrapper.h
@@ -1,5 +1,11 @@
-#ifndef __JANSSON_WRAPPER_H__
-#define __JANSSON_WRAPPER_H__
+/* Node type: Delta Share.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
 
 #include <jansson.h>
 #include <string>
@@ -11,7 +17,6 @@
 namespace DeltaSharing {
 namespace JanssonWrapper {
 
-// RAII wrapper for json_t
 class JsonValue {
 private:
     json_t* m_json;
@@ -226,7 +231,6 @@ public:
     }
 
     // Object manipulation
-    // void set(const std::string& key, const JsonValue& value) {
     void set(const std::string& key, JsonValue value) {
         if (is_object()) {
             json_object_set_new(m_json, key.c_str(), value.release());
@@ -234,7 +238,6 @@ public:
     }
 
     // Array manipulation
-    // void push_back(const JsonValue& value) {
     void push_back(JsonValue value) {
         if (is_array()) {
             json_array_append_new(m_json, value.release());
@@ -250,5 +253,3 @@ using json = JsonValue;
 
 } // namespace JanssonWrapper
 } // namespace DeltaSharing
-
-#endif

--- a/lib/nodes/CMakeLists.txt
+++ b/lib/nodes/CMakeLists.txt
@@ -193,8 +193,8 @@ endif()
 if(WITH_NODE_DELTASHARING)
     list(APPEND NODE_SRC
         delta_sharing/delta_sharing.cpp
-        delta_sharing/DeltaSharingClient.cpp
-        delta_sharing/DeltaSharingRestClient.cpp
+        delta_sharing/delta_sharing_client.cpp
+        delta_sharing/delta_sharing_rest_client.cpp
         delta_sharing/functions.cpp
     )
 
@@ -209,17 +209,6 @@ if(WITH_NODE_DELTASHARING)
     BUILD_COMMAND make
     INSTALL_COMMAND sudo make install
     )
-
-    # ExternalProject_Add(restclient
-    # GIT_REPOSITORY https://github.com/mrtazz/restclient-cpp
-    # GIT_TAG 0.5.2
-    # PREFIX ${CMAKE_BINARY_DIR}/restclient
-    # INSTALL_DIR ${CMAKE_BINARY_DIR}/restclient/install
-    # CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/restclient/install
-    # UPDATE_COMMAND ""
-    # PATCH_COMMAND ""
-    # BUILD_ALWAYS OFF
-    # )
 
     # Create imported target
     add_library(restclient-cpp SHARED IMPORTED)
@@ -236,10 +225,6 @@ if(WITH_NODE_DELTASHARING)
 
 
     list(APPEND LIBRARIES
-        # Arrow::arrow
-        # Parquet::parquet
-        # PkgConfig::Arrow
-        # PkgConfig::Parquet
         restclient-cpp
         PkgConfig::JANSSON
         ${ARROW_LIBRARIES}

--- a/lib/nodes/delta_sharing/delta_sharing.cpp
+++ b/lib/nodes/delta_sharing/delta_sharing.cpp
@@ -1,12 +1,12 @@
 /* Node type: delta_sharing.
  *
- * Author:
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
  * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "villas/nodes/delta_sharing/Protocol.h"
-#include "villas/timing.hpp"
+#include <villas/nodes/delta_sharing/Protocol.h>
+#include <villas/timing.hpp>
 #include <arrow/array/array_base.h>
 #include <arrow/array/array_binary.h>
 #include <arrow/type_fwd.h>

--- a/lib/nodes/delta_sharing/delta_sharing_client.cpp
+++ b/lib/nodes/delta_sharing/delta_sharing_client.cpp
@@ -1,8 +1,14 @@
-#include "villas/nodes/delta_sharing/DeltaSharingClient.h"
+/* Node type: delta_sharing.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <villas/nodes/delta_sharing/delta_sharing_client.h>
 #include <arrow/type_fwd.h>
 #include <parquet/stream_reader.h>
 #include <arrow/io/memory.h>
-//#include <arrow/dataset/dataset.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/exception.h>
 #include <arrow/api.h>

--- a/lib/nodes/delta_sharing/delta_sharing_rest_client.cpp
+++ b/lib/nodes/delta_sharing/delta_sharing_rest_client.cpp
@@ -1,5 +1,12 @@
-#include <villas/nodes/delta_sharing/DeltaSharingRestClient.h>
-#include "villas/nodes/delta_sharing/Protocol.h"
+/* Node type: delta_sharing.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <villas/nodes/delta_sharing/delta_sharing_rest_client.h>
+#include <villas/nodes/delta_sharing/Protocol.h>
 #include <fstream>
 #include <sstream>
 #include <restclient-cpp/restclient.h>

--- a/lib/nodes/delta_sharing/functions.cpp
+++ b/lib/nodes/delta_sharing/functions.cpp
@@ -1,5 +1,12 @@
+/* Node type: delta_sharing.
+ *
+ * Author: Ritesh Karki <ritesh.karki@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstddef>
-#include "villas/nodes/delta_sharing/functions.h"
+#include <villas/nodes/delta_sharing/functions.h>
 
 
 namespace DeltaSharing

--- a/tests/integration/node-deltaSharing.sh
+++ b/tests/integration/node-deltaSharing.sh
@@ -1,66 +1,3 @@
-#!/usr/bin/env bash
-#
-# Test hooks in villas node
-#
-# Author: Ritesh Karki
-# SPDX-FileCopyrightText: 2014-2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
-# SPDX-License-Identifier: Apache-2.0
-
-# set -e
-
-# DIR=$(mktemp -d)
-# pushd ${DIR}
-
-# function finish {
-#     popd
-#     rm -rf ${DIR}
-# }
-
-# trap finish EXIT
-
-# cat > deltaSharingTest.share <<EOF
-# {
-#   "shareCredentialsVersion": 1,
-#   "endpoint": "https://sharing.delta.io/delta-sharing/",
-#   "bearerToken": "faaie590d541265bcab1f2de9813274bf233"
-# }
-# EOF
-
-# cat > config.conf <<EOF
-# nodes = {
-#     node1 = {
-#         type = "delta_sharing"
-#         profile_path = "open-datasets.share"
-#         table_path = "open-datasets.share#delta_sharing.default.COVID_19_NYT"
-#         op = "read"
-#     },
-#     node2 = {
-#         type = "file"
-#         uri = "delta_output.dat"
-#         in = {
-#             epoch_mode = "direct"
-#             read_mode = "all"
-#             eof = "stop"
-#         }
-#         out = {
-
-#         }
-#     }
-
-# }
-# paths = (
-#     {
-#         in = "node1"
-#         out = "node2"
-#     }
-# )
-# EOF
-
-# villas node config.conf
-
-
-
-
 #!/bin/bash
 
 # Delta Share Node Integration Test
@@ -88,7 +25,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 # Helper functions
 log_info() {
@@ -122,8 +59,6 @@ setup_test() {
     # Create test cache directory
     mkdir -p "${TEST_CACHE}"
 
-    # Create test profile for open Delta Sharing server
-    # You'll need to replace this with your actual profile
     cat > "${TEST_PROFILE}" << 'EOF'
 {
   "shareCredentialsVersion": 1,


### PR DESCRIPTION
Created new node delta_sharing which implements the [Delta Sharing protocol](https://delta.io/sharing/) to read and write tables from remote servers. Current implementation includes the ability to parse tables and download entire table data into parquet files which are then stored locally in cache. Currently, it is not possible to read or write to specific chunks of a table which can be implemented if any need arises. 

This node requires packages Apache Arrow (with Parquet support) to be installed locally. This can be automated by a script to set up the required dependencies if VILLASnode is built with delta_share. 