### PR TITLE
fix(python): change isinstance int/bool order

### DIFF
--- a/python/villas/node/formats.py
+++ b/python/villas/node/formats.py
@@ -315,12 +315,12 @@ class Protobuf(Format):
         for value in sample.data:
             pb_value = pb.Value()
 
-            if isinstance(value, int):
-                pb_value.i = value
+            if isinstance(value, bool):
+                pb_value.b = value
             elif isinstance(value, float):
                 pb_value.f = value
-            elif isinstance(value, bool):
-                pb_value.b = value
+            elif isinstance(value, int):
+                pb_value.i = value
             elif isinstance(value, complex):
                 pb_value.z.real = value.real
                 pb_value.z.imag = value.imag


### PR DESCRIPTION
Hello,

while testing things out I accidentally ran the newest pytest version 8.4.2 instead of the fixed version 8.3.5 which is defined in the pyproject.toml file. While running pytest version 8.4.2 I encountered the following deprecation warning.

```bash
================================================================================================= warnings summary ==================================================================================================
python/villas/node/test_formats.py::test_protobuf
python/villas/node/test_formats.py::test_protobuf
  /home/Bekir/Temporär/node/python/villas/node/test_formats.py:60: DeprecationWarning: Field villas.node.Value.i: Expected an int, got a boolean. This will be rejected in 7.34.0, please fix it before that
    raw = pb.dumpb([smp1, smp2])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================== 16 passed, 2 warnings in 3.19s ===========================================================================================
```

Apparently this is caused by checking for isinstance(value, int) first.

```py
#python/villas/node/formats.py
# Lines 318 - 326
if isinstance(value, int):
    pb_value.i = value
elif isinstance(value, float):
    pb_value.f = value
elif isinstance(value, bool):
    pb_value.b = value
elif isinstance(value, complex):
    pb_value.z.real = value.real
    pb_value.z.imag = value.imag
```

isinstance(True, int) and isinstance(False, int) will both return True because bool is a subclass of int.

I thought this might be important regardless of the pytest version because as it is now boolean values are treated or seen as integers? I am honestly not sure how protobuf works, it is the first time I am encountering it.

### Proposed Solution

Changing the order.

```py
if isinstance(value, bool):
    pb_value.b = value
elif isinstance(value, float):
    pb_value.f = value
elif isinstance(value, int):
    pb_value.i = value
elif isinstance(value, complex):
    pb_value.z.real = value.real
    pb_value.z.imag = value.imag
```

### More details

This part is most likely not necessary so you can skip it. Upon further testing I noticed the deprecation warning was caused exactly by the boolean inside the `data` list.

```py
# python/villas/node/test_formats.py
smp1 = Sample(
    ts_origin=Timestamp(123456780),
    ts_received=Timestamp(123456781),
    sequence=4,
    new_frame=True,
    data=[1.0, 2.0, 3.0, True, 42, sqrt(complex(-1))],
)

smp2 = Sample(
    ts_origin=Timestamp(123456789),
    ts_received=Timestamp(123456790),
    sequence=5,
    new_frame=False,
    data=[1.0, 2.0, 3.0, False, 42, sqrt(complex(-1))],
)
```
