### PR TITLE
fix(python): Fix mypy CI checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,7 @@ test:python:
     - pytest --verbose .
     - black --line-length=90 --extend-exclude=".*(\\.pyi|_pb2.py)$" --check .
     - flake8 --max-line-length=90 --extend-exclude="*.pyi,*_pb2.py" .
-    - mypy .
+    - mypy --namespace-packages --explicit-package-bases .
   image: ${DOCKER_IMAGE_DEV}:${DOCKER_TAG}
   needs:
     - job: "build:source: [fedora]"


### PR DESCRIPTION
/cc @pjungkamp 

This should fix the broken mypy CI check caused by the introduction of PEP-420 namespace packages for  the `villas` namespace.