### PR TITLE
fix(ci/arx): Use nix-community/nix-bundle instead of NixOS/bundlers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -267,7 +267,7 @@ pkg:nix:arx:
       nix bundle
       --print-build-logs
       --out-link bundle-arx
-      --bundler github:NixOS/bundlers#toArx
+      --bundler github:nix-community/nix-bundle
       ".#villas-node-${SYSTEM}"
 
     - mkdir -p artifacts


### PR DESCRIPTION
/cc @pjungkamp 

Cherry-picked this CI fix from #920 