### PR TITLE
Proper formatting for libjansson macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,3 +22,11 @@ IncludeCategories:
     Priority: 2
   - Regex: '^".*"$'
     Priority: 4
+
+# Add libjansson foreach macros
+ForEachMacros:
+  - 'json_array_foreach'
+  - 'json_object_foreach'
+  - 'json_object_foreach_safe'
+  - 'json_object_keylen_foreach'
+  - 'json_object_keylen_foreach_safe'

--- a/common/lib/log.cpp
+++ b/common/lib/log.cpp
@@ -141,8 +141,8 @@ void Log::parse(json_t *json) {
     json_t *json_expression;
 
     // cppcheck-suppress unknownMacro
-    json_array_foreach(json_expressions, i, json_expression)
-        expressions.emplace_back(json_expression);
+    json_array_foreach (json_expressions, i, json_expression)
+      expressions.emplace_back(json_expression);
   }
 }
 

--- a/fpga/include/villas/fpga/card_parser.hpp
+++ b/fpga/include/villas/fpga/card_parser.hpp
@@ -44,7 +44,7 @@ public:
     // Parse ignored ip names to list
     size_t index;
     json_t *value;
-    json_array_foreach(ignored_ips_array, index, value) {
+    json_array_foreach (ignored_ips_array, index, value) {
       ignored_ip_names.push_back(json_string_value(value));
     }
 

--- a/fpga/lib/card.cpp
+++ b/fpga/lib/card.cpp
@@ -179,7 +179,7 @@ void CardFactory::loadSwitch(std::shared_ptr<Card> card, json_t *json_paths) {
 
     size_t i;
     json_t *json_path;
-    json_array_foreach(json_paths, i, json_path) {
+    json_array_foreach (json_paths, i, json_path) {
       const char *from, *to;
       int reverse = 0;
 

--- a/fpga/lib/core.cpp
+++ b/fpga/lib/core.cpp
@@ -44,7 +44,7 @@ std::list<IpIdentifier> CoreFactory::parseIpIdentifier(json_t *json_ips) {
 
   const char *ipName;
   json_t *json_ip;
-  json_object_foreach(json_ips, ipName, json_ip) {
+  json_object_foreach (json_ips, ipName, json_ip) {
     const char *vlnv;
 
     json_error_t err;
@@ -168,7 +168,7 @@ CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
 
       const char *irqName;
       json_t *json_irq;
-      json_object_foreach(json_irqs, irqName, json_irq) {
+      json_object_foreach (json_irqs, irqName, json_irq) {
         const char *irqEntry = json_string_value(json_irq);
 
         auto tokens = utils::tokenize(irqEntry, ":");
@@ -223,7 +223,7 @@ CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
       // Now find all slave address spaces this master can access
       const char *bus_name;
       json_t *json_bus;
-      json_object_foreach(json_memory_view, bus_name, json_bus) {
+      json_object_foreach (json_memory_view, bus_name, json_bus) {
 
         // This IP has a memory view => it is a bus master somewhere
 
@@ -239,11 +239,11 @@ CoreFactory::configureIps(std::list<IpIdentifier> orderedIps, json_t *json_ips,
 
         const char *instance_name;
         json_t *json_instance;
-        json_object_foreach(json_bus, instance_name, json_instance) {
+        json_object_foreach (json_bus, instance_name, json_instance) {
 
           const char *block_name;
           json_t *json_block;
-          json_object_foreach(json_instance, block_name, json_block) {
+          json_object_foreach (json_instance, block_name, json_block) {
 
             json_int_t base, high, size;
             json_error_t err;

--- a/fpga/lib/ips/pcie.cpp
+++ b/fpga/lib/ips/pcie.cpp
@@ -111,7 +111,7 @@ void AxiPciExpressBridgeFactory::parse(Core &ip, json_t *cfg) {
 
     json_t *json_bar;
     const char *bar_name;
-    json_object_foreach(json_bars, bar_name, json_bar) {
+    json_object_foreach (json_bars, bar_name, json_bar) {
       unsigned int translation;
 
       json_error_t err;

--- a/fpga/lib/node.cpp
+++ b/fpga/lib/node.cpp
@@ -30,7 +30,7 @@ void NodeFactory::parse(Core &ip, json_t *cfg) {
   if (json_ports && json_is_array(json_ports)) {
     size_t index;
     json_t *json_port;
-    json_array_foreach(json_ports, index, json_port) {
+    json_array_foreach (json_ports, index, json_port) {
       if (not json_is_object(json_port))
         throw ConfigError(json_port, "", "Port {} is not an object", index);
 

--- a/fpga/lib/pcie_card.cpp
+++ b/fpga/lib/pcie_card.cpp
@@ -70,7 +70,7 @@ PCIeCardFactory::make(json_t *json_card, std::string card_name,
   // Parse ignored ip names to list
   size_t index;
   json_t *value;
-  json_array_foreach(ignored_ips_array, index, value) {
+  json_array_foreach (ignored_ips_array, index, value) {
     card->ignored_ip_names.push_back(json_string_value(value));
   }
 

--- a/fpga/lib/utils.cpp
+++ b/fpga/lib/utils.cpp
@@ -280,7 +280,7 @@ int fpga::createCards(json_t *config,
   const char *card_name;
   json_t *json_card;
   std::shared_ptr<fpga::Card> card;
-  json_object_foreach(fpgas, card_name, json_card) {
+  json_object_foreach (fpgas, card_name, json_card) {
     card = createCard(json_card, searchPath, vfioContainer, card_name);
     if (card != nullptr) {
       cards.push_back(card);

--- a/lib/api/universal.cpp
+++ b/lib/api/universal.cpp
@@ -22,7 +22,7 @@ void ChannelList::parse(json_t *json, bool readable, bool writable) {
 
   size_t i;
   json_t *json_channel;
-  json_array_foreach(json, i, json_channel) {
+  json_array_foreach (json, i, json_channel) {
     auto channel = std::make_shared<Channel>();
 
     channel->parse(json_channel);
@@ -73,7 +73,7 @@ void Channel::parse(json_t *json) {
 
       range_options.clear();
 
-      json_array_foreach(json_range, i, json_option) {
+      json_array_foreach (json_range, i, json_option) {
         if (!json_is_string(json_option))
           throw ConfigError(json, err, "node-config-node-api-signals-range",
                             "Channel range options must be strings");

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -287,7 +287,7 @@ json_t *Config::walkStrings(json_t *root, str_walk_fcn_t cb) {
   case JSON_OBJECT:
     new_root = json_object();
 
-    json_object_foreach(root, key, val) {
+    json_object_foreach (root, key, val) {
       new_val = walkStrings(val, cb);
 
       json_object_set_new(new_root, key, new_val);
@@ -298,7 +298,7 @@ json_t *Config::walkStrings(json_t *root, str_walk_fcn_t cb) {
   case JSON_ARRAY:
     new_root = json_array();
 
-    json_array_foreach(root, index, val) {
+    json_array_foreach (root, index, val) {
       new_val = walkStrings(val, cb);
 
       json_array_append_new(new_root, new_val);

--- a/lib/config_helper.cpp
+++ b/lib/config_helper.cpp
@@ -98,7 +98,7 @@ int villas::node::json_to_config(json_t *json, config_setting_t *parent) {
     const char *key;
     json_t *json_value;
 
-    json_object_foreach(json, key, json_value) {
+    json_object_foreach (json, key, json_value) {
       type = json_to_config_type(json_typeof(json_value));
 
       cfg = config_setting_add(parent, key, type);
@@ -113,7 +113,7 @@ int villas::node::json_to_config(json_t *json, config_setting_t *parent) {
     size_t i;
     json_t *json_value;
 
-    json_array_foreach(json, i, json_value) {
+    json_array_foreach (json, i, json_value) {
       type = json_to_config_type(json_typeof(json_value));
 
       cfg = config_setting_add(parent, nullptr, type);
@@ -305,7 +305,7 @@ int villas::node::json_object_extend(json_t *obj, json_t *merge) {
   if (!json_is_object(obj) || !json_is_object(merge))
     return -1;
 
-  json_object_foreach(merge, key, merge_value) {
+  json_object_foreach (merge, key, merge_value) {
     obj_value = json_object_get(obj, key);
     if (obj_value && json_is_object(obj_value))
       ret = json_object_extend(obj_value, merge_value);

--- a/lib/formats/json.cpp
+++ b/lib/formats/json.cpp
@@ -66,7 +66,7 @@ int JsonFormat::unpackFlags(json_t *json_flags, struct Sample *smp) {
 
   size_t i;
   json_t *json_flag;
-  json_array_foreach(json_flags, i, json_flag) {
+  json_array_foreach (json_flags, i, json_flag) {
     char *flag;
     json_error_t err;
     if (auto ret = json_unpack_ex(json_flag, &err, 0, "s", &flag))
@@ -239,7 +239,7 @@ int JsonFormat::unpackSample(json_t *json_smp, struct Sample *smp) {
     smp->flags |= (int)SampleFlags::HAS_SEQUENCE;
   }
 
-  json_array_foreach(json_data, i, json_value) {
+  json_array_foreach (json_data, i, json_value) {
     if (i >= smp->capacity)
       break;
 
@@ -276,7 +276,7 @@ int JsonFormat::unpackSamples(json_t *json_smps, struct Sample *const smps[],
   if (!json_is_array(json_smps))
     return -1;
 
-  json_array_foreach(json_smps, i, json_smp) {
+  json_array_foreach (json_smps, i, json_smp) {
     if (i >= cnt)
       break;
 

--- a/lib/formats/json_edgeflex.cpp
+++ b/lib/formats/json_edgeflex.cpp
@@ -51,7 +51,7 @@ int JsonEdgeflexFormat::unpackSample(json_t *json_smp, struct Sample *smp) {
   if (json_typeof(json_smp) != JSON_OBJECT)
     return -1;
 
-  json_object_foreach(json_smp, key, json_value) {
+  json_object_foreach (json_smp, key, json_value) {
     if (!strcmp(key, "created"))
       json_created = json_incref(json_value);
     else {

--- a/lib/formats/json_reserve.cpp
+++ b/lib/formats/json_reserve.cpp
@@ -143,7 +143,7 @@ int JsonReserveFormat::unpackSample(json_t *json_smp, struct Sample *smp) {
   smp->flags = 0;
   smp->length = 0;
 
-  json_array_foreach(json_data, i, json_value) {
+  json_array_foreach (json_data, i, json_value) {
     const char *name, *unit = nullptr;
     double value;
 

--- a/lib/hook.cpp
+++ b/lib/hook.cpp
@@ -116,7 +116,7 @@ void MultiSignalHook::parse(json_t *json) {
       throw ConfigError(json_signals, "node-config-hook-signals",
                         "Setting 'signals' must be a list of signal names");
 
-    json_array_foreach(json_signals, i, json_signal) {
+    json_array_foreach (json_signals, i, json_signal) {
       if (!json_is_string(json_signal))
         throw ConfigError(json_signal, "node-config-hook-signals",
                           "Invalid value for setting 'signals'");

--- a/lib/hook_list.cpp
+++ b/lib/hook_list.cpp
@@ -22,7 +22,7 @@ void HookList::parse(json_t *json, int mask, Path *o, Node *n) {
 
   size_t i;
   json_t *json_hook;
-  json_array_foreach(json, i, json_hook) {
+  json_array_foreach (json, i, json_hook) {
     int ret;
     const char *type;
     Hook::Ptr h;

--- a/lib/hooks/dp.cpp
+++ b/lib/hooks/dp.cpp
@@ -179,7 +179,7 @@ public:
     if (!fharmonics || !coeffs)
       throw MemoryAllocationError();
 
-    json_array_foreach(json_harmonics, i, json_harmonic) {
+    json_array_foreach (json_harmonics, i, json_harmonic) {
       if (!json_is_integer(json_harmonic))
         throw ConfigError(json_harmonic, "node-config-hook-dp-harmonics",
                           "Setting 'harmonics' must be a list of integers");

--- a/lib/hooks/ebm.cpp
+++ b/lib/hooks/ebm.cpp
@@ -42,7 +42,7 @@ public:
     if (!json_is_array(json_phases))
       throw ConfigError(json_phases, "node-config-hook-ebm-phases");
 
-    json_array_foreach(json_phases, i, json_phase) {
+    json_array_foreach (json_phases, i, json_phase) {
       int voltage, current;
 
       ret = json_unpack_ex(json_phase, &err, 0, "[ i, i ]", &voltage, &current);

--- a/lib/hooks/lua.cpp
+++ b/lib/hooks/lua.cpp
@@ -251,7 +251,7 @@ static void lua_pushjson(lua_State *L, json_t *json) {
   switch (json_typeof(json)) {
   case JSON_OBJECT:
     lua_newtable(L);
-    json_object_foreach(json, key, json_value) {
+    json_object_foreach (json, key, json_value) {
       lua_pushjson(L, json_value);
       lua_setfield(L, -2, key);
     }
@@ -259,7 +259,7 @@ static void lua_pushjson(lua_State *L, json_t *json) {
 
   case JSON_ARRAY:
     lua_newtable(L);
-    json_array_foreach(json, i, json_value) {
+    json_array_foreach (json, i, json_value) {
       lua_pushjson(L, json_value);
       lua_rawseti(L, -2, i);
     }
@@ -359,8 +359,8 @@ void LuaHook::parseExpressions(json_t *json_sigs) {
                       "Setting 'signals' must be a list of dicts");
 
   // cppcheck-suppress unknownMacro
-  json_array_foreach(json_sigs, i, json_sig)
-      expressions.emplace_back(L, json_sig);
+  json_array_foreach (json_sigs, i, json_sig)
+    expressions.emplace_back(L, json_sig);
 
   hasExpressions = true;
 }

--- a/lib/hooks/power.cpp
+++ b/lib/hooks/power.cpp
@@ -225,7 +225,7 @@ public:
 
     size_t i = 0;
     json_t *json_pairings_value;
-    json_array_foreach(json_pairings, i, json_pairings_value) {
+    json_array_foreach (json_pairings, i, json_pairings_value) {
       const char *voltageNameC = nullptr;
       const char *currentNameC = nullptr;
 

--- a/lib/kernel/tc_netem.cpp
+++ b/lib/kernel/tc_netem.cpp
@@ -66,7 +66,7 @@ static int set_delay_distribution(struct rtnl_qdisc *qdisc, json_t *json) {
     if (!data)
       throw MemoryAllocationError();
 
-    json_array_foreach(json, idx, elm) {
+    json_array_foreach (json, idx, elm) {
       if (!json_is_integer(elm))
         return -1;
 

--- a/lib/mapping_list.cpp
+++ b/lib/mapping_list.cpp
@@ -26,7 +26,7 @@ int MappingList::parse(json_t *json) {
   else
     return -1;
 
-  json_array_foreach(json_mapping, i, json_entry) {
+  json_array_foreach (json_mapping, i, json_entry) {
     auto me = std::make_shared<MappingEntry>();
     if (!me)
       throw MemoryAllocationError();

--- a/lib/node_list.cpp
+++ b/lib/node_list.cpp
@@ -50,7 +50,7 @@ int NodeList::parse(json_t *json, NodeList &all) {
     break;
 
   case JSON_ARRAY:
-    json_array_foreach(json, index, elm) {
+    json_array_foreach (json, index, elm) {
       if (!json_is_string(elm))
         goto invalid;
 

--- a/lib/nodes/can.cpp
+++ b/lib/nodes/can.cpp
@@ -135,13 +135,13 @@ int villas::node::can_parse(NodeCompat *n, json_t *json) {
   if (!c->out)
     throw MemoryAllocationError();
 
-  json_array_foreach(json_in_signals, i, json_signal) {
+  json_array_foreach (json_in_signals, i, json_signal) {
     ret = can_parse_signal(json_signal, n->in.signals, c->in, i);
     if (ret)
       throw RuntimeError("at signal {}.", i);
   }
 
-  json_array_foreach(json_out_signals, i, json_signal) {
+  json_array_foreach (json_out_signals, i, json_signal) {
     ret = can_parse_signal(json_signal, n->out.signals, c->out, i);
     if (ret)
       throw RuntimeError("at signal {}.", i);

--- a/lib/nodes/comedi.cpp
+++ b/lib/nodes/comedi.cpp
@@ -65,7 +65,7 @@ static int comedi_parse_direction(struct comedi *c, struct comedi_direction *d,
   if (!d->chanspecs)
     throw MemoryAllocationError();
 
-  json_array_foreach(json_chans, i, json_chan) {
+  json_array_foreach (json_chans, i, json_chan) {
     int num, range, aref;
     ret = json_unpack_ex(json_chan, &err, 0, "{ s: i, s: i, s: i }", "channel",
                          &num, "range", &range, "aref", &aref);

--- a/lib/nodes/exec.cpp
+++ b/lib/nodes/exec.cpp
@@ -73,7 +73,7 @@ int ExecNode::parse(json_t *json) {
 
     size_t i;
     json_t *json_arg;
-    json_array_foreach(json_exec, i, json_arg) {
+    json_array_foreach (json_exec, i, json_arg) {
       if (!json_is_string(json_arg))
         throw ConfigError(json_arg, "node-config-node-exec-exec",
                           "All arguments must be of string type");
@@ -90,7 +90,7 @@ int ExecNode::parse(json_t *json) {
     const char *key;
     json_t *json_value;
 
-    json_object_foreach(json_env, key, json_value) {
+    json_object_foreach (json_env, key, json_value) {
       if (!json_is_string(json_value))
         throw ConfigError(json_value, "node-config-node-exec-environment",
                           "Environment variables must be of string type");

--- a/lib/nodes/iec60870.cpp
+++ b/lib/nodes/iec60870.cpp
@@ -744,7 +744,7 @@ int SlaveNode::parse(json_t *json) {
     size_t i;
     std::optional<ASDUData> last_data = std::nullopt;
 
-    json_array_foreach(json_signals, i, json_signal) {
+    json_array_foreach (json_signals, i, json_signal) {
       auto signal = signals ? signals->getByIndex(i) : Signal::Ptr{};
       auto asdu_data =
           ASDUData::parse(json_signal, last_data, duplicate_ioa_is_sequence);

--- a/lib/nodes/iec61850.cpp
+++ b/lib/nodes/iec61850.cpp
@@ -85,7 +85,7 @@ int villas::node::iec61850_parse_signals(json_t *json_signals,
   if (json_is_array(json_signals)) {
     json_t *json_signal;
     size_t i;
-    json_array_foreach(json_signals, i, json_signal) {
+    json_array_foreach (json_signals, i, json_signal) {
       json_unpack_ex(json_signal, &err, 0, "{ s?: s }", "iec_type", &iec_type);
 
       // Try to deduct the IEC 61850 data type from VILLAS signal format

--- a/lib/nodes/iec61850_goose.cpp
+++ b/lib/nodes/iec61850_goose.cpp
@@ -649,7 +649,7 @@ int GooseNode::parse(json_t *json) {
     json_t *json_key;
     assert(json_is_array(json_keys));
     keys.reserve(json_array_size(json_keys));
-    json_array_foreach(json_keys, index, json_key) {
+    json_array_foreach (json_keys, index, json_key) {
       assert(json_is_object(json_key));
       parseSessionKey(json_key);
     }
@@ -698,7 +698,7 @@ void GooseNode::parseInput(json_t *json) {
       json_t *json_multicast_group;
       assert(json_is_array(json_multicast_groups));
       input.multicast_groups.reserve(json_array_size(json_multicast_groups));
-      json_array_foreach(json_multicast_groups, index, json_multicast_group) {
+      json_array_foreach (json_multicast_groups, index, json_multicast_group) {
         assert(json_is_string(json_multicast_group));
         input.multicast_groups.emplace_back(
             json_string_value(json_multicast_group));
@@ -834,7 +834,7 @@ void GooseNode::parseSubscribers(
   if (!json_is_object(json))
     throw RuntimeError("subscribers is not an object");
 
-  json_object_foreach(json, key, json_subscriber) {
+  json_object_foreach (json, key, json_subscriber) {
     SubscriberConfig sc;
 
     parseSubscriber(json_subscriber, sc);
@@ -852,7 +852,7 @@ void GooseNode::parseInputSignals(
 
   mappings.clear();
 
-  json_array_foreach(json, index, value) {
+  json_array_foreach (json, index, value) {
     char *mapping_subscriber;
     unsigned int mapping_index;
     char *mapping_type_name;
@@ -945,7 +945,7 @@ void GooseNode::parsePublisherData(json_t *json,
   if (!json_is_array(json))
     throw RuntimeError("publisher data is not an array");
 
-  json_array_foreach(json, index, json_signal_or_value) {
+  json_array_foreach (json, index, json_signal_or_value) {
     char const *mms_type = nullptr;
     char const *signal_str = nullptr;
     json_t *json_value = nullptr;
@@ -1038,7 +1038,7 @@ void GooseNode::parsePublishers(json_t *json, std::vector<OutputContext> &ctx) {
   int index;
   json_t *json_publisher;
 
-  json_array_foreach(json, index, json_publisher) {
+  json_array_foreach (json, index, json_publisher) {
     PublisherConfig pc;
 
     parsePublisher(json_publisher, pc);

--- a/lib/nodes/modbus.cpp
+++ b/lib/nodes/modbus.cpp
@@ -808,7 +808,7 @@ unsigned int ModbusNode::parseMappings(std::vector<RegisterMapping> &mappings,
   json_t *signal_json;
   auto signals = getInputSignals(false);
 
-  json_array_foreach(json, i, signal_json) {
+  json_array_foreach (json, i, signal_json) {
     auto signal = signals->getByIndex(i);
 
     mappings.push_back(RegisterMappingSingle::parse(i, signal, signal_json));

--- a/lib/nodes/nanomsg.cpp
+++ b/lib/nodes/nanomsg.cpp
@@ -59,7 +59,7 @@ static int nanomsg_parse_endpoints(struct List *l, json_t *json) {
 
   switch (json_typeof(json)) {
   case JSON_ARRAY:
-    json_array_foreach(json, i, json_val) {
+    json_array_foreach (json, i, json_val) {
       ep = json_string_value(json_val);
       if (!ep)
         return -1;

--- a/lib/nodes/ngsi.cpp
+++ b/lib/nodes/ngsi.cpp
@@ -149,8 +149,8 @@ public:
       json_t *json_metadata;
 
       // cppcheck-suppress unknownMacro
-      json_array_foreach(json_metadatas, j, json_metadata)
-          metadata.emplace_back(json_metadata);
+      json_array_foreach (json_metadatas, j, json_metadata)
+        metadata.emplace_back(json_metadata);
     }
 
     // Metadata: index(integer)=j
@@ -264,7 +264,7 @@ static int ngsi_parse_entity(NodeCompat *n, json_t *json_entity,
   if (strcmp(id, i->entity_id) || strcmp(type, i->entity_type))
     return -2;
 
-  json_array_foreach(json_attrs, l, json_attr) {
+  json_array_foreach (json_attrs, l, json_attr) {
     NgsiAttribute *attr;
     json_error_t err;
     json_t *json_metadata, *json_value;
@@ -299,7 +299,7 @@ static int ngsi_parse_entity(NodeCompat *n, json_t *json_entity,
       return -6;
 
     size_t k;
-    json_array_foreach(json_value, k, json_tuple) {
+    json_array_foreach (json_value, k, json_tuple) {
       struct Sample *smp = smps[k];
 
       // Check sample format
@@ -379,7 +379,7 @@ static int ngsi_parse_signals(json_t *json_signals, struct List *ngsi_signals,
   if (!json_is_array(json_signals))
     return -1;
 
-  json_array_foreach(json_signals, j, json_signal) {
+  json_array_foreach (json_signals, j, json_signal) {
     auto s = node_signals->getByIndex(j);
     auto *a = new NgsiAttribute(json_signal, j, s);
     if (!a)

--- a/lib/nodes/opal_orchestra.cpp
+++ b/lib/nodes/opal_orchestra.cpp
@@ -363,7 +363,7 @@ public:
     json_t *json_signal;
     json_error_t err;
 
-    json_array_foreach(json, i, json_signal) {
+    json_array_foreach (json, i, json_signal) {
       auto signal = signals->getByIndex(i);
 
       const char *nme = nullptr;

--- a/lib/nodes/opendss.cpp
+++ b/lib/nodes/opendss.cpp
@@ -52,7 +52,7 @@ void OpenDSS::parseData(json_t *json, bool in) {
   json_t *json_data;
   json_error_t err;
 
-  json_array_foreach(json, i, json_data) {
+  json_array_foreach (json, i, json_data) {
     if (in) {
       const char *name;
       const char *type;
@@ -82,7 +82,7 @@ void OpenDSS::parseData(json_t *json, bool in) {
 
       size_t n;
       json_t *json_mode;
-      json_array_foreach(a_mode, n, json_mode) {
+      json_array_foreach (a_mode, n, json_mode) {
         const char *mode = json_string_value(json_mode);
         // Assign mode according to the OpenDSS function mode.
         switch (ele.type) {

--- a/lib/nodes/shmem.cpp
+++ b/lib/nodes/shmem.cpp
@@ -72,7 +72,7 @@ int villas::node::shmem_parse(NodeCompat *n, json_t *json) {
 
     size_t i;
     json_t *json_val;
-    json_array_foreach(json_exec, i, json_val) {
+    json_array_foreach (json_exec, i, json_val) {
       val = json_string_value(json_val);
       if (!val)
         throw SystemError("Setting 'exec' must be an array of strings");

--- a/lib/nodes/signal.cpp
+++ b/lib/nodes/signal.cpp
@@ -219,7 +219,7 @@ int SignalNode::parse(json_t *json) {
 
   signals.clear();
   unsigned j = 0;
-  json_array_foreach(json_signals, i, json_signal) {
+  json_array_foreach (json_signals, i, json_signal) {
     auto sig = SignalNodeSignal(json_signal);
 
     if (sig.type == SignalNodeSignal::Type::MIXED)

--- a/lib/nodes/signal_v1.cpp
+++ b/lib/nodes/signal_v1.cpp
@@ -208,7 +208,7 @@ int villas::node::signal_node_parse(NodeCompat *n, json_t *json) {
       throw ConfigError(json_type, "node-config-node-signal",
                         "Length of values must match");
 
-    json_array_foreach(json_type, i, json_value) {
+    json_array_foreach (json_type, i, json_value) {
       type_str = json_string_value(json_value);
       if (!type_str)
         throw ConfigError(json_value, "node-config-node-signal",
@@ -249,7 +249,7 @@ int villas::node::signal_node_parse(NodeCompat *n, json_t *json) {
 
         size_t i;
         json_t *json_value;
-        json_array_foreach(a.json, i, json_value) {
+        json_array_foreach (a.json, i, json_value) {
           if (!json_is_number(json_value))
             throw ConfigError(
                 json_value, "node-config-node-signal",

--- a/lib/nodes/stats.cpp
+++ b/lib/nodes/stats.cpp
@@ -180,7 +180,7 @@ int villas::node::stats_node_parse(NodeCompat *n, json_t *json) {
     throw ConfigError(json, "node-config-node-stats-in-signals",
                       "Setting 'in.signals' must be an array");
 
-  json_array_foreach(json_signals, i, json_signal) {
+  json_array_foreach (json_signals, i, json_signal) {
     auto *stats_sig = new struct stats_node_signal;
     if (!stats_sig)
       throw MemoryAllocationError();

--- a/lib/nodes/test_rtt.cpp
+++ b/lib/nodes/test_rtt.cpp
@@ -203,7 +203,7 @@ int TestRTT::parse(json_t *json) {
                       "The 'cases' setting must be an array.");
 
   int id = 0;
-  json_array_foreach(json_cases, i, json_case) {
+  json_array_foreach (json_cases, i, json_case) {
 
     const char *mode_str = nullptr;
     int count = count_default;          // in no of samples
@@ -242,7 +242,7 @@ int TestRTT::parse(json_t *json) {
 
     if (json_is_array(json_rates)) {
       size_t j;
-      json_array_foreach(json_rates, j, json_val) {
+      json_array_foreach (json_rates, j, json_val) {
         if (!json_is_number(json_val))
           throw ConfigError(
               json_val, "node-config-node-test-rtt-rates",
@@ -255,7 +255,7 @@ int TestRTT::parse(json_t *json) {
 
     if (json_is_array(json_values)) {
       size_t j;
-      json_array_foreach(json_values, j, json_val) {
+      json_array_foreach (json_values, j, json_val) {
         if (!json_is_integer(json_val))
           throw ConfigError(
               json_val, "node-config-node-test-rtt-values",

--- a/lib/nodes/uldaq.cpp
+++ b/lib/nodes/uldaq.cpp
@@ -311,7 +311,7 @@ int villas::node::uldaq_parse(NodeCompat *n, json_t *json) {
   if (!u->in.queues)
     throw MemoryAllocationError();
 
-  json_array_foreach(json_signals, i, json_signal) {
+  json_array_foreach (json_signals, i, json_signal) {
     const char *range_str = nullptr, *input_mode_str = nullptr;
     int channel = -1, input_mode, range;
 

--- a/lib/nodes/webrtc.cpp
+++ b/lib/nodes/webrtc.cpp
@@ -100,7 +100,7 @@ int WebRTCNode::parse(json_t *json) {
 
       size_t i;
       json_t *json_server;
-      json_array_foreach(json_servers, i, json_server) {
+      json_array_foreach (json_servers, i, json_server) {
         if (!json_is_string(json_server))
           throw ConfigError(json_server, "node-config-node-webrtc-ice-server",
                             "ICE servers must be provided as STUN/TURN url.");

--- a/lib/nodes/webrtc/signaling_message.cpp
+++ b/lib/nodes/webrtc/signaling_message.cpp
@@ -62,7 +62,7 @@ RelayMessage::RelayMessage(json_t *json) {
   char *expires;
   json_t *json_server;
   size_t i;
-  json_array_foreach(json, i, json_server) {
+  json_array_foreach (json, i, json_server) {
     ret = json_unpack(json_server, "{ s: s, s: s, s: s, s: s, s: s }", "url",
                       &url, "user", &user, "pass", &pass, "realm", &realm,
                       "expires", &expires);
@@ -106,7 +106,8 @@ ControlMessage::ControlMessage(json_t *j) {
   json_t *json_peer;
   size_t i;
   // cppcheck-suppress unknownMacro
-  json_array_foreach(json_peers, i, json_peer) peers.emplace_back(json_peer);
+  json_array_foreach (json_peers, i, json_peer)
+    peers.emplace_back(json_peer);
 }
 
 json_t *SignalingMessage::toJson() const {

--- a/lib/nodes/websocket.cpp
+++ b/lib/nodes/websocket.cpp
@@ -570,7 +570,7 @@ int villas::node::websocket_parse(NodeCompat *n, json_t *json) {
                         "node-config-node-websocket-destinations",
                         "The 'destinations' setting must be an array of URLs");
 
-    json_array_foreach(json_dests, i, json_dest) {
+    json_array_foreach (json_dests, i, json_dest) {
       const char *uri, *prot, *ads, *path;
 
       uri = json_string_value(json_dest);

--- a/lib/nodes/zeromq.cpp
+++ b/lib/nodes/zeromq.cpp
@@ -110,7 +110,7 @@ static int zeromq_parse_endpoints(json_t *json_ep, struct List *epl) {
 
   switch (json_typeof(json_ep)) {
   case JSON_ARRAY:
-    json_array_foreach(json_ep, i, json_val) {
+    json_array_foreach (json_ep, i, json_val) {
       ep = json_string_value(json_val);
       if (!ep)
         throw ConfigError(json_val, "node-config-node-publish",

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -418,7 +418,7 @@ void Path::parseMask(json_t *json_mask, NodeList &nodes) {
     throw ConfigError(json_mask, "node-config-path-mask",
                       "The 'mask' setting must be a list of node names");
 
-  json_array_foreach(json_mask, i, json_entry) {
+  json_array_foreach (json_mask, i, json_entry) {
     const char *name;
     Node *node;
 

--- a/lib/signal_list.cpp
+++ b/lib/signal_list.cpp
@@ -25,7 +25,7 @@ int SignalList::parse(json_t *json) {
 
   size_t i;
   json_t *json_signal;
-  json_array_foreach(json, i, json_signal) {
+  json_array_foreach (json, i, json_signal) {
     auto sig = std::make_shared<Signal>();
     if (!sig)
       throw MemoryAllocationError();

--- a/lib/super_node.cpp
+++ b/lib/super_node.cpp
@@ -123,7 +123,7 @@ void SuperNode::parse(json_t *root) {
 
     const char *node_name;
     json_t *json_node;
-    json_object_foreach(json_nodes, node_name, json_node) {
+    json_object_foreach (json_nodes, node_name, json_node) {
       uuid_t node_uuid;
       const char *node_type;
       const char *node_uuid_str = nullptr;
@@ -172,7 +172,7 @@ void SuperNode::parse(json_t *root) {
 
     size_t i;
     json_t *json_path;
-    json_array_foreach(json_paths, i, json_path) {
+    json_array_foreach (json_paths, i, json_path) {
     parse:
       auto *p = new Path();
       if (!p)


### PR DESCRIPTION
I noticed that we haven't properly configured clang-format for libjansson's `foreach` macros. Let's fix that.