### PR TITLE
node shmem: Reset Sample::signals before writing to shared memory

### DIFF
--- a/lib/nodes/shmem.cpp
+++ b/lib/nodes/shmem.cpp
@@ -176,6 +176,10 @@ int villas::node::shmem_write(NodeCompat *n, struct Sample *const smps[],
   if (copied < avail)
     n->logger->warn("Outgoing pool underrun");
 
+  /* signals is a heap shared_ptr; a reader in another process can't deref it */
+  for (int i = 0; i < copied; i++)
+    shared_smps[i]->signals.reset();
+
   pushed = shmem_int_write(&shm->intf, shared_smps, copied);
   if (pushed != avail)
     n->logger->warn("Outgoing queue overrun for node");


### PR DESCRIPTION
The shmem node writes samples whose `signals` field is a `std::shared_ptr` into the writer's heap. A reader in another process dereferences that pointer while copying the sample and crashes.

Discovered when using two villas-node processes with shmem, it segfaults at the first read.
