### PR TITLE
 node shmem: Reset Sample::signals before writing to shared memory

### DIFF
--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -194,6 +194,10 @@ int villas::node::shmem_int_write(struct ShmemInterface *shm,
 
   atomic_fetch_add(&shm->writers, 1);
 
+  // Signals is a heap shared_ptr; a reader in another process can't deref it.
+  for (unsigned i = 0; i < cnt; i++)
+    const_cast<struct Sample *>(smps[i])->signals.reset();
+
   ret =
       queue_signalled_push_many(&shm->write.shared->queue, (void **)smps, cnt);
 


### PR DESCRIPTION
The shmem node writes samples whose `signals` field is a `std::shared_ptr` into the writer's heap. A reader in another process dereferences that pointer while copying the sample and crashes.

Discovered when using two villas-node processes with shmem, it segfaults at the first read.