### PR TITLE
dp hook: reconstruct harmonics at k*f0, not k Hz

### DIFF
--- a/lib/hooks/dp.cpp
+++ b/lib/hooks/dp.cpp
@@ -81,7 +81,7 @@ protected:
 
     // Reconstruct the original signal
     for (int k = 0; k < fharmonics_len; k++) {
-      double freq = fharmonics[k];
+      double freq = fharmonics[k] * f0;
       // cppcheck-suppress objectIndex
       std::complex<double> coeff = in[k];
       std::complex<double> om = 2.0i * M_PI * freq * time;


### PR DESCRIPTION
The inverse dp transformation treated `fharmonics[k]` as a frequency in Hz, but it is a list for indexes (`k*f0`), same than the direct transformation uses. So each component was rebuilt at k Hz instead of k*f0 making the fundamental to be approx 1 Hz.