### PR TITLE
ci: run fork pull requests via pull_request_target behind a review gate

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
       docker_image:
         required: true
         type: string
+      ref:
+        required: true
+        type: string
 
 env:
   CMAKE_BUILD_OPTS: --parallel $(nproc)
@@ -24,7 +27,7 @@ jobs:
     name: "Build Source [${{ matrix.distro }}]"
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.docker_image }}/dev-${{ matrix.image_name }}:${{ github.sha }}
+      image: ${{ inputs.docker_image }}/dev-${{ matrix.image_name }}:${{ inputs.ref }}
       options: --user root
     strategy:
       fail-fast: false
@@ -68,6 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -76,7 +80,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-fedora-${{ github.sha }}
+          key: ccache-fedora-${{ inputs.ref }}
           restore-keys: ccache-fedora-
 
       - name: Configure

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,6 +5,10 @@ name: Checks
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Lint OpenAPI Specification
         run: npx -y @redocly/cli lint --config doc/redocly.yaml doc/openapi/openapi.yaml
@@ -43,6 +49,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Add Git safe Directory
         run: git config --global --add safe.directory '*'
@@ -66,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
     branches: [master]
     tags: ["v*"]
   pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 concurrency:
@@ -17,9 +18,16 @@ concurrency:
 jobs:
   setup:
     name: Setup Variables
+    # Forks get a read-only GITHUB_TOKEN, so they run via pull_request_target.
+    if: >-
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork
+      || github.event_name != 'pull_request_target' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request_target' && 'fork-pr' || 'internal' }}
     outputs:
       docker_image: ${{ steps.image.outputs.docker_image }}
+      ref: ${{ steps.ref.outputs.ref }}
+      ref_name: ${{ steps.ref.outputs.ref_name }}
     steps:
       - name: Compute image name for the current repository
         id: image
@@ -27,20 +35,39 @@ jobs:
           OWNER: ${{ github.repository_owner }}
         run: echo "docker_image=ghcr.io/${OWNER,,}/villas/node" >> "$GITHUB_OUTPUT"
 
+      # Under pull_request_target GITHUB_SHA and GITHUB_REF_NAME point at the base branch.
+      - name: Resolve the revision under test
+        id: ref
+        env:
+          REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          REF_NAME: ${{ github.event_name == 'pull_request_target' && format('{0}/merge', github.event.pull_request.number) || github.ref_name }}
+        run: |
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "ref_name=$REF_NAME" >> "$GITHUB_OUTPUT"
+
   checks:
     name: Run Checks
+    needs: [setup]
     secrets: inherit
     uses: ./.github/workflows/checks.yaml
+    with:
+      ref: ${{ needs.setup.outputs.ref }}
 
   paper:
     name: Build Paper Draft
+    needs: [setup]
     secrets: inherit
     uses: ./.github/workflows/paper.yaml
+    with:
+      ref: ${{ needs.setup.outputs.ref }}
 
   nix:
     name: Build with Nix
+    needs: [setup]
     secrets: inherit
     uses: ./.github/workflows/nix.yaml
+    with:
+      ref: ${{ needs.setup.outputs.ref }}
 
   prepare:
     name: Prepare Docker Images
@@ -49,6 +76,8 @@ jobs:
     uses: ./.github/workflows/prepare.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref: ${{ needs.setup.outputs.ref }}
+      ref_name: ${{ needs.setup.outputs.ref_name }}
 
   build:
     name: Build from Source
@@ -57,6 +86,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref: ${{ needs.setup.outputs.ref }}
 
   test:
     name: Run Tests
@@ -65,6 +95,7 @@ jobs:
     uses: ./.github/workflows/test.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref: ${{ needs.setup.outputs.ref }}
 
   packaging-docker:
     name: Build Docker Images
@@ -73,6 +104,8 @@ jobs:
     uses: ./.github/workflows/packaging-docker.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref: ${{ needs.setup.outputs.ref }}
+      ref_name: ${{ needs.setup.outputs.ref_name }}
 
   packaging-nix:
     name: Bundle Artifacts with Nix
@@ -81,6 +114,8 @@ jobs:
     uses: ./.github/workflows/packaging-nix.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref: ${{ needs.setup.outputs.ref }}
+      ref_name: ${{ needs.setup.outputs.ref_name }}
 
   deploy:
     name: Deploy Docker Images
@@ -89,6 +124,8 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref: ${{ needs.setup.outputs.ref }}
+      ref_name: ${{ needs.setup.outputs.ref_name }}
       is_version_tag: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
   deploy-nix:
@@ -98,6 +135,7 @@ jobs:
     uses: ./.github/workflows/deploy-nix.yaml
     with:
       docker_image: ${{ needs.setup.outputs.docker_image }}
+      ref_name: ${{ needs.setup.outputs.ref_name }}
       is_version_tag: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
   all:

--- a/.github/workflows/deploy-nix.yaml
+++ b/.github/workflows/deploy-nix.yaml
@@ -9,6 +9,9 @@ on:
       docker_image:
         required: true
         type: string
+      ref_name:
+        required: true
+        type: string
       is_version_tag:
         required: false
         type: boolean
@@ -39,7 +42,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Create and Push Multi-arch Nix Manifest
         run: |
@@ -66,7 +71,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Tag Nix Manifest as latest-nix
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,12 @@ on:
       docker_image:
         required: true
         type: string
+      ref:
+        required: true
+        type: string
+      ref_name:
+        required: true
+        type: string
       is_version_tag:
         required: false
         type: boolean
@@ -39,7 +45,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Create and push multi-arch manifest
         run: |
@@ -64,7 +72,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Publish dev image for current ref
         run: |
@@ -88,13 +98,15 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Publish dev-vscode image for current ref
         run: |
           docker buildx imagetools create \
             -t "${{ env.DOCKER_IMAGE }}/dev-vscode:${{ steps.ref.outputs.tag }}" \
-            "${{ env.DOCKER_IMAGE }}/dev-vscode:${{ github.sha }}"
+            "${{ env.DOCKER_IMAGE }}/dev-vscode:${{ inputs.ref }}"
 
   latest-docker:
     name: Docker Images as latest
@@ -114,7 +126,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Tag and Push Image as latest
         run: |
@@ -141,7 +155,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Tag and push dev image as latest
         run: |

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -5,6 +5,10 @@ name: Nix
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -21,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 

--- a/.github/workflows/packaging-docker.yaml
+++ b/.github/workflows/packaging-docker.yaml
@@ -9,6 +9,12 @@ on:
       docker_image:
         required: true
         type: string
+      ref:
+        required: true
+        type: string
+      ref_name:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -30,6 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -45,7 +52,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Image
         uses: docker/build-push-action@v7
@@ -73,6 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -88,7 +98,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Image
         uses: docker/build-push-action@v7

--- a/.github/workflows/packaging-nix.yaml
+++ b/.github/workflows/packaging-nix.yaml
@@ -9,6 +9,12 @@ on:
       docker_image:
         required: true
         type: string
+      ref:
+        required: true
+        type: string
+      ref_name:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -30,6 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -69,6 +76,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -108,6 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -130,7 +139,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Push to Registry
         env:

--- a/.github/workflows/paper.yaml
+++ b/.github/workflows/paper.yaml
@@ -4,6 +4,10 @@ name: Draft PDF
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 jobs:
   paper:
@@ -13,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Build Draft PDF
         uses: openjournals/openjournals-draft-action@v1.0

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -9,11 +9,17 @@ on:
       docker_image:
         required: true
         type: string
+      ref:
+        required: true
+        type: string
+      ref_name:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
   DOCKER_IMAGE: ${{ inputs.docker_image }}
-  DOCKER_TAG: ${{ github.sha }}
+  DOCKER_TAG: ${{ inputs.ref }}
 
 permissions:
   contents: read
@@ -53,6 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -68,7 +75,9 @@ jobs:
 
       - name: Compute safe ref Tag
         id: ref
-        run: echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
+        run: echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Image
         uses: docker/build-push-action@v7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
       docker_image:
         required: true
         type: string
+      ref:
+        required: true
+        type: string
 
 env:
   CMAKE_BUILD_OPTS: --parallel $(nproc)
@@ -26,12 +29,13 @@ jobs:
     name: Python
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.docker_image }}/dev-fedora:${{ github.sha }}
+      image: ${{ inputs.docker_image }}/dev-fedora:${{ inputs.ref }}
       options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -59,12 +63,13 @@ jobs:
     name: CPPCheck
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.docker_image }}/dev-fedora:${{ github.sha }}
+      image: ${{ inputs.docker_image }}/dev-fedora:${{ inputs.ref }}
       options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -82,12 +87,13 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.docker_image }}/dev-fedora:${{ github.sha }}
+      image: ${{ inputs.docker_image }}/dev-fedora:${{ inputs.ref }}
       options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -101,7 +107,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-fedora-${{ github.sha }}
+          key: ccache-fedora-${{ inputs.ref }}
           restore-keys: ccache-fedora-
 
       - name: Configure
@@ -114,7 +120,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.docker_image }}/dev-fedora:${{ github.sha }}
+      image: ${{ inputs.docker_image }}/dev-fedora:${{ inputs.ref }}
       options: --user root
     services:
       rabbitmq:
@@ -125,6 +131,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -138,7 +145,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-fedora-${{ github.sha }}
+          key: ccache-fedora-${{ inputs.ref }}
           restore-keys: ccache-fedora-
 
       - name: Start Mosquitto


### PR DESCRIPTION
Fork PRs like #1020 fail from `prepare` onward, because fork runs get a read-only `GITHUB_TOKEN` and cannot push to ghcr.

Forks can now run via `pull_request_target`, which is safe because each run needs approval from a member. Nothing changes for same-repo PRs. Tags are unchanged.

Needs the env `fork-pr` to be created with required reviewers before merge. Sorry @stv0g, I will need to make you work a bit extra because this needs admin rights.