### PR TITLE
ci: allow fork PR checkout under pull_request_target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Lint OpenAPI Specification
         run: npx -y @redocly/cli lint --config doc/redocly.yaml doc/openapi/openapi.yaml
@@ -51,6 +52,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Add Git safe Directory
         run: git config --global --add safe.directory '*'
@@ -76,6 +78,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -20,8 +20,11 @@ jobs:
     name: Setup Variables
     # Forks get a read-only GITHUB_TOKEN, so they run via pull_request_target.
     if: >-
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork
-      || github.event_name != 'pull_request_target' && !github.event.pull_request.head.repo.fork
+      github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+      || github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      || github.event_name == 'pull_request_target'
+      && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'pull_request_target' && 'fork-pr' || 'internal' }}
     outputs:
@@ -139,7 +142,16 @@ jobs:
       is_version_tag: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
   all:
-    name: All prerequisites completed
+    # Only the real run may claim the required check name. Mirrors setup.
+    name: >-
+      ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+      || github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      || github.event_name == 'pull_request_target'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'All prerequisites completed' || 'CI not applicable' }}
+    # A skipped required check counts as passing.
+    if: always()
     needs:
       - setup
       - checks
@@ -155,7 +167,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dependency barrier
-        run: echo "All prerequisite jobs finished."
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
 
   tag-minor-release:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 

--- a/.github/workflows/packaging-docker.yaml
+++ b/.github/workflows/packaging-docker.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -68,7 +69,7 @@ jobs:
           cache-from: |
             type=gha,scope=dev-debian
             type=gha,scope=app-x86_64
-          cache-to: type=gha,mode=max,scope=app-x86_64
+          cache-to: ${{ github.event_name != 'pull_request_target' && 'type=gha,mode=max,scope=app-x86_64' || '' }}
           build-args: |
             ARCH=x86_64
             TRIPLET=x86_64-linux-gnu
@@ -83,6 +84,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -112,7 +114,7 @@ jobs:
           pull: true
           platforms: linux/arm64
           cache-from: type=gha,scope=app-arm64
-          cache-to: type=gha,mode=max,scope=app-arm64
+          cache-to: ${{ github.event_name != 'pull_request_target' && 'type=gha,mode=max,scope=app-arm64' || '' }}
           build-args: |
             ARCH=arm64
             TRIPLET=aarch64-linux-gnu

--- a/.github/workflows/packaging-nix.yaml
+++ b/.github/workflows/packaging-nix.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -77,6 +78,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -117,6 +119,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 

--- a/.github/workflows/paper.yaml
+++ b/.github/workflows/paper.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Build Draft PDF
         uses: openjournals/openjournals-draft-action@v1.0

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -87,7 +88,7 @@ jobs:
           target: ${{ matrix.target || 'dev' }}
           push: true
           cache-from: type=gha,scope=dev-${{ matrix.image_name }}
-          cache-to: type=gha,mode=max,scope=dev-${{ matrix.image_name }}
+          cache-to: ${{ github.event_name != 'pull_request_target' && format('type=gha,mode=max,scope=dev-{0}', matrix.image_name) || '' }}
           tags: |
             ${{ env.DOCKER_IMAGE }}/dev-${{ matrix.image_name }}:${{ env.DOCKER_TAG }}
             ${{ env.DOCKER_IMAGE }}/dev-${{ matrix.image_name }}:${{ steps.ref.outputs.tag }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -70,6 +71,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -94,6 +96,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 
@@ -132,6 +135,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           submodules: recursive
 


### PR DESCRIPTION
'Fork PRs still fail after #1032. `actions/checkout@v7` refuses to check out fork code from a `pull_request_target` workflow unless `allow-unsafe-pr-checkout: true` is set. Approval by a member is already required by the `fork-pr` env, so this should be safe.

Other smaller fixes
- GitHub refuses Actions cache writes for fork runs, so `cache-to` is disabled for that event. Reads are unchanged.
- Splits the concurrency group by event so the two runs stop cancelling each other.
- Fixes `all`, which was skipped instead of failed when a prerequisite failed. Only the real run claims the required check name now.
- Compares the head repo full name instead of using `head.repo.fork`, which is wrong when the base repo is itself a fork.

Verified using cross-repo PR leonardocarreras/node#2
