### PR TITLE
ci: check REUSE compliance in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,11 @@ repos:
         exclude: ^paper\.md$
         args: [-r, "~MD013,~MD033,~MD024"]
 
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: "v6.2.0"
+    hooks:
+      - id: reuse-lint-file
+
   - repo: local
     hooks:
       - id: dco-hook


### PR DESCRIPTION
REUSE is only checked in CI, so nothing catches a missing SPDX header locally. Adds the `reuse-lint-file` hook from `fsfe/reuse-tool`, pinned to `v6.2.0` to match `fsfe/reuse-action@v6`.

`lint-file` judges only the files a commit touches; the workflow keeps linting the whole tree for project-level drift. Verified passing on a compliant file and failing on one without a header; `pre-commit run --all-files` stays green over all 1120 files in ~2s. Needs pre-commit on Python 3.10+, which the `python:3.12` CI container satisfies.

Same hook and pin as sogno-platform/dpsim#602.

See also #1035, which touches this file in a different place.
