### PR TITLE
Remove deprecated usage of pkgs.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,9 +94,12 @@
 
         # Cross-compiled packages
         villas-node-x86_64-linux =
-          if pkgs.system == "x86_64-linux" then pkgs.villas-node else pkgs.pkgsCross.x86_64-linux.villas-node;
+          if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then
+            pkgs.villas-node
+          else
+            pkgs.pkgsCross.x86_64-linux.villas-node;
         villas-node-aarch64-linux =
-          if pkgs.system == "aarch64-linux" then
+          if pkgs.stdenv.hostPlatform.system == "aarch64-linux" then
             pkgs.villas-node
           else
             pkgs.pkgsCross.aarch64-multiplatform.villas-node;

--- a/packaging/nix/villas.nix
+++ b/packaging/nix/villas.nix
@@ -7,7 +7,6 @@
   # General configuration
   src,
   version,
-  system,
   withGpl ? true,
   withAllExtras ? false,
   withAllFormats ? false,
@@ -16,7 +15,7 @@
   # Extra features
   withExtraConfig ? withAllExtras,
   withExtraGraphviz ? withAllExtras,
-  withExtraTesting ? (withAllExtras && system == "x86_64-linux"),
+  withExtraTesting ? (withAllExtras && stdenv.hostPlatform.system == "x86_64-linux"),
   # Format-types
   withFormatProtobuf ? withAllFormats,
   # Hook-types
@@ -24,7 +23,7 @@
   # Node-types
   withNodeAmqp ? withAllNodes,
   withNodeComedi ? withAllNodes,
-  withNodeEthercat ? (withAllNodes && system == "x86_64-linux"),
+  withNodeEthercat ? (withAllNodes && stdenv.hostPlatform.system == "x86_64-linux"),
   withNodeIec60870 ? withAllNodes,
   withNodeIec61850 ? withAllNodes,
   withNodeInfiniband ? withAllNodes,
@@ -33,7 +32,7 @@
   withNodeMqtt ? withAllNodes,
   withNodeNanomsg ? withAllNodes,
   withNodeOpenDSS ? withAllNodes,
-  withNodeOpalOrchestra ? (withAllNodes && system == "x86_64-linux"),
+  withNodeOpalOrchestra ? (withAllNodes && stdenv.hostPlatform.system == "x86_64-linux"),
   withNodeRedis ? withAllNodes,
   withNodeRtp ? withAllNodes,
   withNodeSocket ? withAllNodes,


### PR DESCRIPTION
To avoid deprecation warnings in our Nix flake.