### PR TITLE
feat(nodes): Add c37.118 node-type with WITH_NODE_C37_118 build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ add_compile_options(
 check_include_file("sys/eventfd.h" HAS_EVENTFD)
 check_include_file("semaphore.h" HAS_SEMAPHORE)
 check_include_file("sys/mman.h" HAS_MMAN)
+check_include_file("netdb.h" HAS_NETDB)
+check_include_file("poll.h" HAS_POLL)
 
 # Use the switch NO_EVENTFD to deactivate eventfd usage indepentent of availability on OS
 if(${NO_EVENTFD})
@@ -194,6 +196,7 @@ cmake_dependent_option(WITH_TOOLS               "Build auxilary tools"          
 cmake_dependent_option(WITH_WEB                 "Build with internal webserver"                         "${WITH_DEFAULTS}" "LIBWEBSOCKETS_FOUND" OFF)
 
 cmake_dependent_option(WITH_NODE_AMQP           "Build with amqp node-type"                             "${WITH_DEFAULTS}" "RABBITMQ_C_FOUND" OFF)
+cmake_dependent_option(WITH_NODE_C37_118        "Build with c37_118 node-type"                          "${WITH_DEFAULTS}" "HAS_NETDB; HAS_POLL" OFF)
 cmake_dependent_option(WITH_NODE_CAN            "Build with can node-type"                              "${WITH_DEFAULTS}" "" OFF)
 cmake_dependent_option(WITH_NODE_COMEDI         "Build with comedi node-type"                           "${WITH_DEFAULTS}" "COMEDILIB_FOUND" OFF)
 cmake_dependent_option(WITH_NODE_ETHERCAT       "Build with ethercat node-type"                         "${WITH_DEFAULTS}" "ETHERLAB_FOUND; NOT WITHOUT_GPL" OFF)

--- a/lib/nodes/CMakeLists.txt
+++ b/lib/nodes/CMakeLists.txt
@@ -6,8 +6,11 @@
 
 set(NODE_SRC
     loopback_internal.cpp
-    c37_118.cpp
 )
+
+if(WITH_NODE_C37_118)
+    list(APPEND NODE_SRC c37_118.cpp)
+endif()
 
 if(LIBNL3_ROUTE_FOUND)
     list(APPEND LIBRARIES PkgConfig::LIBNL3_ROUTE)

--- a/tests/integration/node-c37_118.sh
+++ b/tests/integration/node-c37_118.sh
@@ -8,6 +8,11 @@
 
 set -e
 
+if ! villas node -h | grep -q '^ - c37\.118\b'; then
+    echo "The c37.118 node-type is not supported by this build"
+    exit 99
+fi
+
 DIR=$(mktemp -d)
 pushd ${DIR}
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(TEST_SRC
-    c37_118.cpp
     config_json.cpp
     config.cpp
     format.cpp
@@ -19,6 +18,10 @@ set(TEST_SRC
     queue.cpp
     signal.cpp
 )
+
+if(WITH_NODE_C37_118)
+    list(APPEND TEST_SRC c37_118.cpp)
+endif()
 
 add_executable(unit-tests ${TEST_SRC})
 target_link_libraries(unit-tests PUBLIC


### PR DESCRIPTION
**Disclaimer:** the title should be (fix) but I deliverately picked (feat) to make release-please to know that the node was there, the actual feat is #1023 (merged), so will get a correct minor bump

_What it actually does here:_

- Create the option for building with/without WITH_NODE_C37_118
- Wire the test and the skip message
- Add checks for netdb and poll, it might need some comments from the original creator @pjungkamp to see if this is the correct way

Closes #1046 and will help with #1045 