### PR TITLE
Fix sample compare for timestamps

### DIFF
--- a/lib/sample.cpp
+++ b/lib/sample.cpp
@@ -206,7 +206,7 @@ int villas::node::sample_cmp(struct Sample *a, struct Sample *b, double epsilon,
 
   // Compare timestamp
   if (flags & (int)SampleFlags::HAS_TS_ORIGIN) {
-    if (time_delta(&a->ts.origin, &b->ts.origin) > epsilon) {
+    if (abs(time_delta(&a->ts.origin, &b->ts.origin)) > epsilon) {
       printf("ts.origin: %f != %f\n", time_to_double(&a->ts.origin),
              time_to_double(&b->ts.origin));
       return 3;

--- a/tests/integration/node-hook.sh
+++ b/tests/integration/node-hook.sh
@@ -74,4 +74,4 @@ EOF
 
 villas node config.json
 
-villas compare output.dat expect.dat
+villas compare -T output.dat expect.dat

--- a/tests/integration/node-mapping.sh
+++ b/tests/integration/node-mapping.sh
@@ -80,4 +80,4 @@ EOF
 
 villas node -d debug  config.json
 
-villas compare output.dat expect.dat
+villas compare -T output.dat expect.dat

--- a/tests/integration/node-multiplexing.sh
+++ b/tests/integration/node-multiplexing.sh
@@ -117,7 +117,7 @@ EOF
 
 villas node config.json
 
-villas compare output.dat expect_${MODE}.dat
+villas compare -T output.dat expect_${MODE}.dat
 
 rm output.dat
 


### PR DESCRIPTION
Sample time compare only compared for a positive time diff. Now changed to an abs compare.